### PR TITLE
Bake tooling VIPC when a repo has no project .vipc

### DIFF
--- a/.github/workflows/build-labview-image.yml
+++ b/.github/workflows/build-labview-image.yml
@@ -554,8 +554,18 @@ jobs:
           $date  = '${{ steps.date.outputs.date }}'
           $wv    = '${{ steps.ver.outputs.version }}'
           $lcwcBase = '${{ steps.base.outputs.image }}'
-          $vipcCount = [int]'${{ steps.vipc.outputs.count }}'
-          $dragonCount = [int]'${{ steps.vipc.outputs.dragon_count }}'
+          # Count what labview-ci.Dockerfile will actually COPY + apply: every .vipc /
+          # .dragon staged into .github/labview/vipm. That ALWAYS includes the baseline
+          # tooling VIPC (ci-tooling.vipc -> Caraya / VI Tester / LUnit CLI / the UTF
+          # JUnit essentials) on top of any staged project deps. Previously this used
+          # steps.vipc.outputs (project + capability files only), so a repo whose deps
+          # live solely in ci-tooling.vipc (no project .vipc) reported depCount=0 and took
+          # the crane registry-copy fast path, publishing the worker as a plain copy of the
+          # LCWC base with NO tooling baked -- the registered CLI operations (e.g. LUnit)
+          # were then missing and headless unit tests failed (-350006). Match the
+          # worker-version step, which already hashes these same files.
+          $vipcCount = @(Get-ChildItem '.github/labview/vipm' -Filter *.vipc -File -ErrorAction SilentlyContinue).Count
+          $dragonCount = @(Get-ChildItem '.github/labview/vipm' -Filter *.dragon -File -ErrorAction SilentlyContinue).Count
           $depCount = $vipcCount + $dragonCount
           $unitTestsInstalled = $false
           $inActivities = $false
@@ -626,7 +636,9 @@ jobs:
           $base   = '${{ env.IMAGE_NAME }}'
           $wv     = '${{ steps.ver.outputs.version }}'
           $img    = "${base}:${wv}"
-          $workerLayer = if (([int]'${{ steps.vipc.outputs.count }}' + [int]'${{ steps.vipc.outputs.dragon_count }}') -gt 0) { 'repo-vipc-layer' } else { 'seed-only-copy' }
+          # Mirror the bake decision in build-and-push: a worker is a built layer whenever
+          # any .vipc/.dragon in .github/labview/vipm was applied (always incl. ci-tooling.vipc).
+          $workerLayer = if ((@(Get-ChildItem '.github/labview/vipm' -Filter *.vipc -File -ErrorAction SilentlyContinue).Count + @(Get-ChildItem '.github/labview/vipm' -Filter *.dragon -File -ErrorAction SilentlyContinue).Count) -gt 0) { 'repo-vipc-layer' } else { 'seed-only-copy' }
           $outDir = "ci-out/workers-pages/workers/windows/$wv"
           New-Item -ItemType Directory -Force -Path 'ci-out/worker' | Out-Null
           New-Item -ItemType File -Force -Path 'ci-out/worker/nipkg-list.txt','ci-out/worker/vipm-list.txt' | Out-Null


### PR DESCRIPTION
Hi,

Thanks for quick turn around on merging the LUnit addition. While testing it I noticed an issue which prevented unit tests from being run (unless there happens to be a vipc file in the repository).

The worker image build decided between baking dependencies (docker build via labview-ci.Dockerfile) and a fast crane registry-copy of the LCWC base using `depCount = vipcCount + dragonCount`, where the counts came from the staging step's  steps.vipc.outputs` -- which only counts PROJECT .vipc files (those outside .github/) plus capability VIPCs.

A repo whose dependencies live solely in the generated baseline tooling VIPC (.github/labview/vipm/ci-tooling.vipc -> Caraya / VI Tester / LUnit CLI / the UTF JUnit essentials) and that has no project .vipc therefore reported depCount=0 and took the crane-copy path. That publishes the worker as a byte-identical copy of the shared LCWC base, so ci-tooling.vipc is never applied. 

This was inconsistent with the "Compute worker version" step, which already hashes .github/labview/vipm/*.vipc (so the version eflected ci-tooling.vipc even though the bake decision ignored it).

Fix: base both the bake decision (build-and-push) and the worker-layer label (Generate worker manifest) on the actual contents of .github/labview/vipm, exactly what labview-ci.Dockerfile COPYs and applies, so the worker is built whenever there is any tooling/project VIPC to bake.

I tested this on one of my repos, With the fix, it builds a new docker image with the proper tooling and the unit testing works.

/Anton