### PR TITLE
Bake a no-VIPM-repo package by committing its .vip

### DIFF
--- a/.github/labview/vipm/README.md
+++ b/.github/labview/vipm/README.md
@@ -87,6 +87,26 @@ To add **custom** project dependencies: commit a `.vipc` (made in the VIPM
 editor, or generated like `ci-tooling.vipc`) at the repo root or under
 `.github/labview/vipm/`, then rebuild the image. No script changes are needed.
 
+### Baking a package that is on no VIPM repository (commit its `.vip`)
+
+A package published on **no** VIPM repository — e.g. an in-house framework — cannot
+be resolved by name from the public indexes. Rather than standing up a private VIPM
+mirror, **commit the package's `.vip` file to the repo** and reference the package in
+a `.vipc`:
+
+1. Commit the `.vip` anywhere outside `.github/` (the build stages every repo `*.vip`
+   into `.github/labview/vipm/`, next to the VIPCs). Keep VIPM's canonical export name
+   `<package-id>-<version>.vip` so its id + version are read correctly.
+2. Reference that package (id + version) in a `.vipc` you apply (a project
+   `Dependencies.vipc` or `ci-tooling`). The `.vipc` must also list the package's
+   dependency closure (OpenG, etc.), because dependencies are **not** read out of the
+   committed `.vip` — they are resolved from the `.vipc` like any other package.
+
+When applying that `.vipc`, `install-vipc.ps1` uses the committed `.vip` **in preference
+to the public mirror** (and it is the only way a no-index package resolves at all). A
+committed `.vip` that is **not** referenced by any applied `.vipc` is never installed on
+its own.
+
 ---
 
 ## What we learned getting VIPM to run headless in a Windows container

--- a/.github/labview/vipm/install-vipc.ps1
+++ b/.github/labview/vipm/install-vipc.ps1
@@ -491,8 +491,79 @@ function Save-PublicVipmPackage($Package, [string] $OutDir) {
     return $outFile
 }
 
+# Index the local .vip package files staged into the worker (C:\vipm) so a
+# VIPC-referenced package can be installed FROM THE COMMITTED .vip instead of being
+# downloaded from the public mirrors. This is the supported way to bake a package
+# that is published on NO VIPM repository (e.g. an in-house framework) without a
+# private mirror: commit its .vip and reference the package in a .vipc. A loose .vip
+# is only ever used when an applied .vipc references it - it is never installed on
+# its own.
+#
+# NOTE: -Filter '*.vip' ALSO matches '*.vipc' (Windows 8.3 wildcard), so enumerate
+# and filter on the exact extension instead. Package id + version come from the file
+# name (VIPM's canonical export form '<package-id>-<version>.vip'); the package's
+# internal 'spec' is read as a best-effort override when the file was renamed.
+function Get-LocalVipFileIndex([string] $Dir) {
+    $index = New-Object System.Collections.Generic.List[object]
+    if (-not $Dir -or -not (Test-Path -LiteralPath $Dir)) { return @($index.ToArray()) }
+    $vipFiles = @(Get-ChildItem -LiteralPath $Dir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -eq '.vip' })
+    foreach ($f in $vipFiles) {
+        $name = ''
+        $version = ''
+        $base = [System.IO.Path]::GetFileNameWithoutExtension($f.Name)
+        if ($base -match '^(?<n>.+)-(?<v>\d+(?:\.\d+)+)(?:-\d+)?$') {
+            $name = $Matches.n
+            $version = $Matches.v
+        }
+        # Best-effort override from the package's internal 'spec' (a .vip is a zip).
+        try {
+            Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+            $zip = [System.IO.Compression.ZipFile]::OpenRead($f.FullName)
+            try {
+                $entry = $zip.Entries | Where-Object { $_.Name -eq 'spec' } | Select-Object -First 1
+                if ($entry) {
+                    $reader = New-Object System.IO.StreamReader($entry.Open())
+                    try { $specText = $reader.ReadToEnd() } finally { $reader.Close() }
+                    $mN = [regex]::Match($specText, '(?im)^\s*Package(?:\s*Name)?\s*=\s*"?(?<v>[A-Za-z0-9_.\-]+)"?\s*$')
+                    if ($mN.Success) { $name = $mN.Groups['v'].Value.Trim() }
+                    $mV = [regex]::Match($specText, '(?im)^\s*Version\s*=\s*"?(?<v>\d+(?:\.\d+)+)"?')
+                    if ($mV.Success) { $version = $mV.Groups['v'].Value.Trim() }
+                }
+            } finally { $zip.Dispose() }
+        } catch { }
+        if (-not $name) { $name = $base }
+        $index.Add([pscustomobject]@{
+            Name       = $name
+            Version    = $version
+            VersionKey = Get-NumericVersionKey $version
+            File       = $f.FullName
+        })
+    }
+    return @($index.ToArray())
+}
+
+# Pick the best local .vip for a request, mirroring Select-PublicVipmPackage's
+# name + (exact | minimum) version matching.
+function Select-LocalVipPackage($Request, [object[]] $LocalVips) {
+    $cands = @($LocalVips | Where-Object { $_.Name -ieq $Request.Name })
+    if ($cands.Count -eq 0) { return $null }
+    if ($Request.Version) {
+        if ($Request.Minimum) {
+            $minKey = Get-NumericVersionKey $Request.Version
+            $cands = @($cands | Where-Object { $_.VersionKey -ge $minKey })
+        } else {
+            $cands = @($cands | Where-Object { $_.Version -eq $Request.Version })
+        }
+    }
+    if ($cands.Count -eq 0) { return $null }
+    return @($cands | Sort-Object VersionKey -Descending | Select-Object -First 1)[0]
+}
+
 function Get-LocalVipFilesForSpecs([string[]] $Specs) {
     $repoPackages = @(Get-PublicVipmRepositoryPackages)
+    # Committed .vip files take priority over the public mirrors when applying.
+    $localVips = @(Get-LocalVipFileIndex $VipcDir)
     $rootRequests = @($Specs | ForEach-Object { Split-VipmPackageSpec $_ })
     $exactByName = @{}
     foreach ($root in $rootRequests) {
@@ -511,6 +582,25 @@ function Get-LocalVipFilesForSpecs([string[]] $Specs) {
         if ($visited.ContainsKey($key)) { return }
         if ($visiting.ContainsKey($key)) { return }
         $visiting[$key] = $true
+        # Prefer a committed local .vip over the public mirrors. This also resolves a
+        # package that is in NO public index (e.g. an in-house framework): its
+        # dependencies are not parsed from the .vip - they come from the .vipc, which
+        # enumerates the full closure as separate specs that resolve on their own.
+        $local = Select-LocalVipPackage $Request $localVips
+        if ($local) {
+            if (-not $visitedPackageIds.ContainsKey($local.File)) {
+                $resolved.Add([pscustomobject]@{
+                    Id        = ('{0}-{1}' -f $local.Name, $local.Version)
+                    Name      = $local.Name
+                    Version   = $local.Version
+                    LocalFile = $local.File
+                })
+                $visitedPackageIds[$local.File] = $true
+            }
+            $visited[$key] = $true
+            $visiting.Remove($key)
+            return
+        }
         $pkg = Select-PublicVipmPackage $Request $repoPackages
         if (-not $pkg) {
             $vtext = if ($Request.Version) { " version '$($Request.Version)'" } else { '' }
@@ -543,7 +633,14 @@ function Get-LocalVipFilesForSpecs([string[]] $Specs) {
     foreach ($root in $rootRequests) { Resolve-One $root $false }
     $downloadDir = Join-Path $env:TEMP 'vipm-package-files'
     $files = New-Object System.Collections.Generic.List[string]
-    foreach ($pkg in $resolved) { $files.Add((Save-PublicVipmPackage $pkg $downloadDir)) }
+    foreach ($pkg in $resolved) {
+        if ($pkg.PSObject.Properties.Name -contains 'LocalFile' -and $pkg.LocalFile) {
+            Write-Host "  Using committed local .vip for $($pkg.Id): $(Split-Path $pkg.LocalFile -Leaf)"
+            $files.Add($pkg.LocalFile)
+        } else {
+            $files.Add((Save-PublicVipmPackage $pkg $downloadDir))
+        }
+    }
     return @($files.ToArray() | Select-Object -Unique)
 }
 

--- a/.github/pages/documentation.html
+++ b/.github/pages/documentation.html
@@ -1085,6 +1085,17 @@ docker run --rm `
         repositories, including old OpenG <code>sf://opengtoolkit</code> URLs and the legacy
         <code>jki_vi_tester</code> alias. Private/custom VIPM repositories still require either a populated VIPM
         resolver cache, a committed offline VIPC that embeds package files, or direct package-file URLs.</div>
+      <div class="note"><span class="lbl">Baking a package on no VIPM repository</span>
+        A package published on <strong>no</strong> public index (e.g. an in-house framework) can be baked without a
+        private mirror by <strong>committing its <code>.vip</code></strong> anywhere outside <code>.github/</code>; the
+        build stages every repo <code>*.vip</code> into <code>.github/labview/vipm/</code> next to the VIPCs (the glob
+        <code>*.vip</code> does not match <code>*.vipc</code>, and the worker-version hash matches the exact extension so
+        VIPCs are not double-counted). Reference the package by id + version in an applied <code>.vipc</code> and keep
+        VIPM's canonical export name <code>&lt;package-id&gt;-&lt;version&gt;.vip</code> so its id + version parse. When that
+        <code>.vipc</code> is applied, <code>install-vipc.ps1</code> uses the committed <code>.vip</code> in preference to
+        the public mirror, and it is the only way a no-index package resolves at all. The <code>.vipc</code> must still
+        enumerate the package's dependency closure (OpenG, etc.) — deps are not parsed from the committed <code>.vip</code>
+        — and a committed <code>.vip</code> that no applied <code>.vipc</code> references is never installed on its own.</div>
       <div class="warn"><span class="lbl">Why the UTF JUnit reporter is mandatory for unit tests</span>
         The built-in <code>LabVIEWCLI -OperationName RunUnitTests</code> links against
         <code>ni_lib_utf_junit_report</code>. Without it baked in, headless UTF runs fail with error

--- a/.github/workflows/build-labview-image.yml
+++ b/.github/workflows/build-labview-image.yml
@@ -435,9 +435,29 @@ jobs:
                   print('Configured Dragon not found (skipping):', p)
           if not dstaged:
               print('No Dragon files to stage.')
+
+          # Project .vip package files: a package published on NO VIPM repository
+          # (e.g. an in-house framework) can be committed as a raw .vip and baked
+          # directly. Discover every repo *.vip outside .github/ and stage it next to
+          # the VIPCs; install-vipc.ps1 uses it in preference to the public mirror, but
+          # ONLY when a .vipc being applied references that package. (glob '*.vip' does
+          # not match '*.vipc', so no extension collision here.)
+          vpaths = sorted(
+              p for p in glob.glob('**/*.vip', recursive=True)
+              if not p.replace(os.sep, '/').startswith('.github/')
+          )
+          vstaged = 0
+          for p in vpaths:
+              if os.path.isfile(p):
+                  shutil.copy2(p, dest / os.path.basename(p))
+                  print('Staged VIP:', p); vstaged += 1
+          if not vstaged:
+              print('No VIP files to stage.')
+
           with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as out:
               out.write(f'count={staged}\n')
               out.write(f'dragon_count={dstaged}\n')
+              out.write(f'vip_count={vstaged}\n')
           PY
       - name: Ensure Docker daemon is running
         shell: powershell
@@ -520,18 +540,23 @@ jobs:
         run: |
           $vipcFiles = @(Get-ChildItem '.github/labview/vipm' -Filter *.vipc -File | Sort-Object Name)
           $dragonFiles = @(Get-ChildItem '.github/labview/vipm' -Filter *.dragon -File | Sort-Object Name)
+          # -Filter '*.vip' also matches '*.vipc' (Windows 8.3 wildcard); match the exact
+          # extension so committed local .vip payloads are hashed without double-counting VIPCs.
+          $vipFiles = @(Get-ChildItem '.github/labview/vipm' -File | Where-Object { $_.Extension -eq '.vip' } | Sort-Object Name)
           $files = @()
-          if ($vipcFiles.Count -gt 0 -or $dragonFiles.Count -gt 0) {
+          if ($vipcFiles.Count -gt 0 -or $dragonFiles.Count -gt 0 -or $vipFiles.Count -gt 0) {
             $files += '.github/docker/labview-ci.Dockerfile'
             $files += '.github/labview/vipm/install-vipc.ps1'
             $files += ($vipcFiles | ForEach-Object FullName)
             $files += ($dragonFiles | ForEach-Object FullName)
+            $files += ($vipFiles | ForEach-Object FullName)
           }
           $parts = @(
             'lcwc-base-image=${{ steps.base.outputs.image }}',
             'lcwc-base-digest=${{ steps.base.outputs.digest }}',
             ('vipc-count={0}' -f $vipcFiles.Count),
-            ('dragon-count={0}' -f $dragonFiles.Count)
+            ('dragon-count={0}' -f $dragonFiles.Count),
+            ('vip-count={0}' -f $vipFiles.Count)
           )
           $parts += foreach ($f in $files) {
             if (Test-Path -LiteralPath $f) {

--- a/actions/dashboard/documentation.html
+++ b/actions/dashboard/documentation.html
@@ -1085,6 +1085,17 @@ docker run --rm `
         repositories, including old OpenG <code>sf://opengtoolkit</code> URLs and the legacy
         <code>jki_vi_tester</code> alias. Private/custom VIPM repositories still require either a populated VIPM
         resolver cache, a committed offline VIPC that embeds package files, or direct package-file URLs.</div>
+      <div class="note"><span class="lbl">Baking a package on no VIPM repository</span>
+        A package published on <strong>no</strong> public index (e.g. an in-house framework) can be baked without a
+        private mirror by <strong>committing its <code>.vip</code></strong> anywhere outside <code>.github/</code>; the
+        build stages every repo <code>*.vip</code> into <code>.github/labview/vipm/</code> next to the VIPCs (the glob
+        <code>*.vip</code> does not match <code>*.vipc</code>, and the worker-version hash matches the exact extension so
+        VIPCs are not double-counted). Reference the package by id + version in an applied <code>.vipc</code> and keep
+        VIPM's canonical export name <code>&lt;package-id&gt;-&lt;version&gt;.vip</code> so its id + version parse. When that
+        <code>.vipc</code> is applied, <code>install-vipc.ps1</code> uses the committed <code>.vip</code> in preference to
+        the public mirror, and it is the only way a no-index package resolves at all. The <code>.vipc</code> must still
+        enumerate the package's dependency closure (OpenG, etc.) — deps are not parsed from the committed <code>.vip</code>
+        — and a committed <code>.vip</code> that no applied <code>.vipc</code> references is never installed on its own.</div>
       <div class="warn"><span class="lbl">Why the UTF JUnit reporter is mandatory for unit tests</span>
         The built-in <code>LabVIEWCLI -OperationName RunUnitTests</code> links against
         <code>ni_lib_utf_junit_report</code>. Without it baked in, headless UTF runs fail with error


### PR DESCRIPTION
Some project dependencies are published on no VIPM repository (e.g. an in-house tooling/frameworks/libraries). The installer resolves every .vipc package against the public NI/JKI indexes and downloads the .vip, so such a package can never install.

Let a repo commit the package's .vip directly and have the worker use it as the payload source. The .vipc stays the source of truth for WHAT installs (and the dependency closure); a committed .vip is only ever used when an applied .vipc references that package, and it is preferred over the public mirror.

install-vipc.ps1:
- Get-LocalVipFileIndex: index C:\vipm\*.vip (extension-exact -- '-Filter *.vip'  also matches *.vipc via the Windows 8.3 wildcard). Package id+version from VIPM's canonical '<id>-<version>.vip' file name, with the internal 'spec' as a best-effort  override.
- Select-LocalVipPackage: name + exact/minimum version match, mirroring Select-PublicVipmPackage.
- Get-LocalVipFilesForSpecs: check the local index first; a match is used directly (no download) and resolves even for a package in NO public index. Its dependencies are not parsed from the .vip -- the .vipc enumerates the closure as separate specs.

build-labview-image.yml:
- Stage every repo *.vip (outside .github/) into .github/labview/vipm next to the VIPCs (glob '*.vip' does not match '*.vipc').
- Fold staged .vip files into the worker-version hash (extension-exact enumeration).

README: document committing a .vip for a no-VIPM-repo package.