### PR TITLE
fix: authenticate to GHCR before pulling Linux worker images

### DIFF
--- a/.github/workflows/masscompile-linux-container.yml
+++ b/.github/workflows/masscompile-linux-container.yml
@@ -139,6 +139,14 @@ jobs:
           fi
           bash .github/labview/wait-for-worker-image.sh "${{ steps.sha.outputs.sha }}" "${{ github.event.before }}" "$LINUX_WORKER_WORKFLOW"
 
+      - name: Log in to GHCR
+        if: env.LABVIEW_CONTAINER_IMAGE != 'nationalinstruments/labview:latest-linux'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull LabVIEW Linux container
         id: pull
         run: docker pull ${{ env.LABVIEW_CONTAINER_IMAGE }}

--- a/.github/workflows/masscompile-linux-container.yml
+++ b/.github/workflows/masscompile-linux-container.yml
@@ -40,6 +40,7 @@ permissions:
   pages: write
   statuses: write
   packages: read
+  actions: read   # so wait-for-worker-image.sh can read the worker-image build runs
 
 # No shared concurrency group: this Linux report deploys to gh-pages directly
 # with no group. The Windows report workflows

--- a/.github/workflows/vidiff-linux-container.yml
+++ b/.github/workflows/vidiff-linux-container.yml
@@ -34,6 +34,8 @@ env:
 permissions:
   contents: read
   statuses: write
+  packages: read
+  actions: read   # so wait-for-worker-image.sh can read the worker-image build runs
 
 jobs:
   vidiff-linux:
@@ -165,6 +167,14 @@ jobs:
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: env.LABVIEW_CONTAINER_IMAGE != 'nationalinstruments/labview:latest-linux'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull LabVIEW Linux container
         run: docker pull ${{ env.LABVIEW_CONTAINER_IMAGE }}


### PR DESCRIPTION
The Linux VIDiff and Mass Compile container workflows pulled the private ghcr.io/<owner>/<repo>-labview worker image without logging in to GHCR, so docker pull failed with "unauthorized". Their Windows counterparts work only because they have a docker/login-action step plus packages: read permission.

Add a guarded "Log in to GHCR" step (skipped when the resolved image is the public NI base image) before the pull in both Linux workflows, and grant vidiff-linux the packages: read and actions: read permissions it was missing (masscompile-linux already had packages: read).