### PR TITLE
Restore the version of record to 4.13.0 and guard against another downgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# Review gate for the LabVIEW CI release machinery.
+#
+# This repository is the tooling SOURCE for every installed client. catalog.json
+# in particular is the version of record: release.yml reads it to cut the tag and
+# force-move the v<major> alias that clients pin to, so an edit here publishes to
+# all of them. These paths are never routine changes.
+#
+# NOTE: CODEOWNERS does nothing until "Require a pull request before merging" and
+# "Require review from Code Owners" are enabled for main under
+# Settings > Branches > Branch protection rules. See .github/CONTRIBUTING.md.
+
+# The version of record and the client-redirect pointer.
+/.github/labview-ci/catalog.json                    @elijah286
+/.github/labview-ci/source.json                     @elijah286
+
+# Release + publishing workflows.
+/.github/workflows/release.yml                      @elijah286
+/.github/workflows/promote-release.yml              @elijah286
+/.github/workflows/catalog-source-sync.yml          @elijah286
+/.github/workflows/discover-clients.yml             @elijah286
+/.github/workflows/integrate-deploy.yml             @elijah286
+
+# The guard that enforces all of the above.
+/.github/labview/validate-catalog-source-sync.py    @elijah286
+/.github/labview/promote-release.py                 @elijah286
+
+# The configurator/installer pages clients are served.
+/.github/pages/integrate.html                       @elijah286
+/.github/pages/configure.html                       @elijah286
+/.github/pages/whats-new.html                       @elijah286

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to LabVIEW CI
+
+This repository is the **tooling source**, not a client. Every repo listed on the
+dashboard's Clients page installs from here, so a few things behave differently
+than they would in a normal project.
+
+## This repo is not a place to install the pipeline
+
+The **LabVIEW CI configurator** (the "Integrate this CI pipeline" page) is a
+*client installer*. It vendors a tooling payload pinned to a released version and
+deletes files it does not recognise as current tooling.
+
+This repository carries release machinery that no client has — `release.yml`,
+`promote-release.py`, `discover-clients.yml`, the configurator pages themselves.
+So running the configurator against this repo **or a fork of it** deletes that
+machinery and overwrites `catalog.json` with an older version.
+
+That is not hypothetical. On 2026-07-30 an install pinned at v4.11.10 landed on a
+fork, downgraded the catalog from 4.12.4, removed 48 source-only files, and
+stopped all client releases for two weeks.
+
+The configurator now refuses this, and `catalog-source-sync` fails the PR if the
+source-only files go missing. **To test the pipeline, install it into a separate
+scratch repository.**
+
+## `catalog.json` is the version of record
+
+`.github/labview-ci/catalog.json` → `version` is what `release.yml` reads to cut
+the `v<MAJOR>.<MINOR>.<PATCH>` tag and force-move the `v<MAJOR>` alias that every
+client pins to. It is release machinery, not a config file.
+
+- **Never hand-edit it on a feature branch**, and never resolve a conflict in it
+  by taking your side. If your branch's copy is older than main's, take main's.
+- The version must only ever go **up**. `catalog-source-sync` compares it against
+  the highest published `v*` tag and fails the PR if it moves backwards.
+- `version` must equal `history.releases[0].version`, so a bump means adding a
+  history entry too.
+- Patch for fixes, minor for a new capability, major for a breaking change.
+
+A downgrade fails quietly if it gets through: `release.yml` finds the tag already
+exists, publishes nothing, and leaves the alias stranded on the newer release. It
+looks like a green build.
+
+## Reverts
+
+If a PR is reverted, do **not** bring it back by merging main into your fork and
+re-merging your branch — git treats the reverted commits as already merged, so
+they silently return. Revert the revert (`git revert <revert-sha>`) on a fresh
+branch, fix the actual problem, and open a new PR.
+
+This is how the 2026-07-30 downgrade came back seven minutes after it was fixed.
+
+## Repository settings this relies on
+
+The guards are only as good as the branch rules that enforce them. On `main`,
+under **Settings › Branches › Branch protection rules**:
+
+- Require a pull request before merging
+- Require review from Code Owners (activates `.github/CODEOWNERS`)
+- Require status checks to pass → **`Catalog Source Sync`**
+
+Without the required status check, `catalog-source-sync` reports a failure that
+nothing acts on.

--- a/.github/labview-ci/catalog.json
+++ b/.github/labview-ci/catalog.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "version": "4.11.10",
+  "version": "4.13.0",
   "stableVersion": "4.10.0",
-  "betaVersion": "4.11.8",
+  "betaVersion": "4.11.10",
   "name": "LabVIEW CI",
   "description": "Portable, repo-agnostic CI/CD capabilities for LabVIEW repositories: mass compile, VI Analyzer, VIDiff comparison reports, VI snapshots / VI Browser, and a status dashboard. Driven entirely by this catalog so the configurator UI and the installer stay in sync and new capabilities are a one-entry change.",
   "installPause": {
@@ -13,17 +13,76 @@
   "history": {
     "comment": "Release notes for the tooling, newest first. `version` (above) is the CURRENT published release and MUST equal releases[0].version. The dashboard version badge and the What's New dialog read these notes to tell a consumer what changed between the version they run and the latest this source repo publishes. Each published version should also be tagged v<version> in this repo so consumers can pin an update to a specific release. `stableVersion` (top level, optional) names the newest release the maintainer has promoted to the stable channel, and each such release entry is flagged \"stable\": true; installs and upgrades default to the stable channel and fall back to `version` (the beta tip) only while no stable release has been promoted yet. `betaVersion` is the same pointer for the beta (release-candidate) channel, with entries flagged \"beta\": true. The install/upgrade channel picker is cumulative: release only (stable), release+beta (beta), or release+beta+dev (every published build).",
     "releases": [
-      {"version": "4.11.10", "date": "2026-07-23", "notes": "Windows Debug Run: the container started and VNC connected, but the desktop was black - LabVIEW launches in session 0 without its window shown/foregrounded. The container script now actively shows + brings the LabVIEW window to the foreground (maximized) as it loads, and logs which top-level windows exist, to fix and diagnose the black-desktop case."},
-      {"version": "4.11.9", "date": "2026-07-23", "notes": "What's New: the update-channel picker (Release / Release + beta / Release + beta + dev) now only appears on client repositories, not on the source/root repo, which is the source of truth everyone upgrades from and never upgrades itself; the owner's per-release Mark-as-beta/stable buttons are unchanged."},
-      {"version": "4.11.8", "date": "2026-07-23", "beta": true, "notes": "VI Analyzer report gained a Windows/Linux platform toggle. When a commit was analyzed on both platforms, a segmented Windows | Linux control under the report title lets you switch between the two reports (matching the Mass Compile report); the other platform's button is disabled with a note when VI Analyzer has not run there for that commit."},
-      {"version": "4.11.7", "date": "2026-07-23", "beta": true, "notes": "Release channels are now three tiers: Dev (default, every published build), Beta (release candidate) and Stable (release). The install and What's New dialogs gained a cumulative channel picker (Release only / Release + beta / Release + beta + dev); the dashboard update indicator and What's New resolve the chosen tier; release.yml moves a rolling 'beta' git tag beside 'stable'; and the owner's What's New page gained per-release 'Mark as beta' and 'Mark as stable' buttons (promote-release.yml gained a tier input). This build is marked Beta, and the default channel for every client is Release + beta."},
-      {"version": "4.11.6", "date": "2026-07-23", "notes": "Fix: Windows debug desktop showed \"Server is not configured properly\" in noVNC and rejected every connection. TightVNC in app mode reads its config from the registry, not the MSI's service settings, so it started requiring VNC auth with no app-mode password set. Configure the app-mode registry directly with VNC authentication disabled (the one-time tunnel URL, which already carries the password, is the access gate) so the server accepts the noVNC connection."},
-      {"version": "4.11.5", "date": "2026-07-23", "notes": "Fix: Windows debug tunnels went dead (NXDOMAIN) seconds after connecting. The noVNC bridge + Cloudflare tunnel were launched with Start-Process, whose children live in the step's Windows job object and get killed when that step ends - so the tunnel was torn down while the container kept holding. Launch them via WMI (Win32_Process.Create) so they run outside the step's job object and stay up for the whole session."},
-      {"version": "4.11.4", "date": "2026-07-23", "notes": "Fix: Windows debug sessions never actually started. The container was launched with -p 127.0.0.1:5900:5900, but Windows containers cannot bind a host IP in NAT, so docker run errored and no container came up - yet the tunnel still published a URL that pointed at nothing. Publish the port without the 127.0.0.1 prefix, and fail the job loudly if the container does not start."},
-      {"version": "4.11.3", "date": "2026-07-22", "notes": "Debug Run: the \"Open source\" button now boots the same debug container but opens the LabVIEW project (*.lvproj) in the IDE so you can view the source over VNC, instead of just linking to GitHub. It sends a new open_source input; the Linux and Windows container scripts find the project in the checkout and launch LabVIEW with it."},
-      {"version": "4.11.2", "date": "2026-07-22", "notes": "Debug Run: added an \"Open source\" button next to Start debug session. It skips booting a container and just opens the chosen revision's source tree on GitHub in a new tab, for when you only need to read the code rather than run it."},
-      {"version": "4.11.1", "date": "2026-07-22", "notes": "Debug Run no longer replaces the form when you start a session. The configuration form now stays put and each session you start appears in a scrollable \"Existing debug sessions\" list beneath it (with its live progress bar, Open and End), so you can launch several at once - extra ones queue and start as earlier sessions finish - and reconnect to or end any of them from any device."},
-      {"version": "4.11.0", "date": "2026-07-22", "notes": "Debug Run now supports Windows containers, not just Linux. Pick Linux or Windows in the dialog; the activity list adjusts to what each platform can run. A Windows session boots the Windows worker with an interactive desktop (TightVNC captures the LabVIEW IDE) and bridges it out over noVNC + a Cloudflare tunnel, the same one-click remote-desktop experience as Linux."},
+      {"version": "4.13.0", "date": "2026-08-17", "notes": "SBOM Generation: a new Windows capability that runs a LabVIEW SBOM headlessly in the worker container via VIPM CLI and publishes a CycloneDX report to the dashboard, detecting the container's installed LabVIEW version automatically and failing the run rather than emitting a misleading report. Also: the dashboard no longer attempts to publish GitHub Pages for pull requests from forks (which cannot hold the required token), and the documentation's sections 16.1-16.6 gained fully worked replication examples. This release also restores the catalog after an accidental downgrade to 4.11.10, which had left 4.11.11 through 4.12.4 unpublished to clients."},
+      {"version": "4.12.4", "date": "2026-07-23", "notes": "Debug Run: simplified the dialog to a single Start debug session button on a chosen revision (activities are no longer pre-selected), added a warning that each session occupies one of the project's Actions runners and blocks other CI jobs when no slots are free, and added an on-screen operations menu in the Linux container (first option opens the project; the rest run Mass Compile, Builds, VIDiff, etc. and stream output live)."},
+      {"version": "4.12.3", "date": "2026-07-23", "notes": "Debug Run is now Linux-only: removed the Windows container option from the dialog, since Windows containers run in session 0 with no interactive desktop (a Microsoft limitation) so the VNC view is always blank. The primary action is now \"Open the project\" (boots the desktop with the LabVIEW project open); \"Run activities...\" is the secondary action. Windows headless CI is unaffected."},
+      {"version": "4.12.2", "date": "2026-07-23", "notes": "VI Analyzer report: the \"testing errors\" banner now names each VI that could not be loaded/analyzed, shows its actual error message, and tags CI-tooling VIs (under .github/) separately -- so a bare count like \"9 VI not loadable\" now explains exactly which VIs failed and whether they are CI helper VIs (harmless) or your project code. The parser also reads the native report\u2019s <h3>-headed error tables, which it previously skipped."},
+      {"version": "4.12.1", "date": "2026-07-23", "notes": "Windows Debug Run diagnostics: the black screen persists even after aligning window stations, so the container now enumerates every desktop on WinSta0 and the top-level windows on each, to pin down exactly which desktop LabVIEW's window lands on (or whether it renders no window at all in the container's session 0)."},
+      {"version": "4.12.0", "date": "2026-07-23", "notes": "VI Analyzer report: because LabVIEW is a graphical language, each VI card now embeds its rendered front panel and block diagram snapshot inline (lazily loaded from the VI Browser gallery when you expand a VI) so the findings sit beside the actual code, with an \"Open full view\" control for the larger interactive drawer. The report also always offers a \"Download raw report\" link to the native LabVIEW VI Analyzer HTML it was built from."},
+      {"version": "4.11.12", "date": "2026-07-23", "notes": "Windows Debug Run black-screen fix: diagnostics confirmed LabVIEW runs but has no window on the desktop VNC shows - the container entrypoint and its child processes (LabVIEW, the prompt) run on a non-interactive service window station, while TightVNC captures the interactive WinSta0\\Default. The container script now switches to WinSta0\\Default before launching TightVNC and LabVIEW so they share the interactive desktop."},
+      {
+        "version": "4.11.11",
+        "date": "2026-07-23",
+        "notes": "Marked v4.11.10 as a beta (release candidate). Users on the release+beta channel receive it; the default release channel is unaffected."
+      },
+      {
+        "version": "4.11.10",
+        "date": "2026-07-23",
+        "notes": "Windows Debug Run: the container started and VNC connected, but the desktop was black - LabVIEW launches in session 0 without its window shown/foregrounded. The container script now actively shows + brings the LabVIEW window to the foreground (maximized) as it loads, and logs which top-level windows exist, to fix and diagnose the black-desktop case.",
+        "beta": true
+      },
+      {
+        "version": "4.11.9",
+        "date": "2026-07-23",
+        "notes": "What's New: the update-channel picker (Release / Release + beta / Release + beta + dev) now only appears on client repositories, not on the source/root repo, which is the source of truth everyone upgrades from and never upgrades itself; the owner's per-release Mark-as-beta/stable buttons are unchanged."
+      },
+      {
+        "version": "4.11.8",
+        "date": "2026-07-23",
+        "beta": true,
+        "notes": "VI Analyzer report gained a Windows/Linux platform toggle. When a commit was analyzed on both platforms, a segmented Windows | Linux control under the report title lets you switch between the two reports (matching the Mass Compile report); the other platform's button is disabled with a note when VI Analyzer has not run there for that commit."
+      },
+      {
+        "version": "4.11.7",
+        "date": "2026-07-23",
+        "beta": true,
+        "notes": "Release channels are now three tiers: Dev (default, every published build), Beta (release candidate) and Stable (release). The install and What's New dialogs gained a cumulative channel picker (Release only / Release + beta / Release + beta + dev); the dashboard update indicator and What's New resolve the chosen tier; release.yml moves a rolling 'beta' git tag beside 'stable'; and the owner's What's New page gained per-release 'Mark as beta' and 'Mark as stable' buttons (promote-release.yml gained a tier input). This build is marked Beta, and the default channel for every client is Release + beta."
+      },
+      {
+        "version": "4.11.6",
+        "date": "2026-07-23",
+        "notes": "Fix: Windows debug desktop showed \"Server is not configured properly\" in noVNC and rejected every connection. TightVNC in app mode reads its config from the registry, not the MSI's service settings, so it started requiring VNC auth with no app-mode password set. Configure the app-mode registry directly with VNC authentication disabled (the one-time tunnel URL, which already carries the password, is the access gate) so the server accepts the noVNC connection."
+      },
+      {
+        "version": "4.11.5",
+        "date": "2026-07-23",
+        "notes": "Fix: Windows debug tunnels went dead (NXDOMAIN) seconds after connecting. The noVNC bridge + Cloudflare tunnel were launched with Start-Process, whose children live in the step's Windows job object and get killed when that step ends - so the tunnel was torn down while the container kept holding. Launch them via WMI (Win32_Process.Create) so they run outside the step's job object and stay up for the whole session."
+      },
+      {
+        "version": "4.11.4",
+        "date": "2026-07-23",
+        "notes": "Fix: Windows debug sessions never actually started. The container was launched with -p 127.0.0.1:5900:5900, but Windows containers cannot bind a host IP in NAT, so docker run errored and no container came up - yet the tunnel still published a URL that pointed at nothing. Publish the port without the 127.0.0.1 prefix, and fail the job loudly if the container does not start."
+      },
+      {
+        "version": "4.11.3",
+        "date": "2026-07-22",
+        "notes": "Debug Run: the \"Open source\" button now boots the same debug container but opens the LabVIEW project (*.lvproj) in the IDE so you can view the source over VNC, instead of just linking to GitHub. It sends a new open_source input; the Linux and Windows container scripts find the project in the checkout and launch LabVIEW with it."
+      },
+      {
+        "version": "4.11.2",
+        "date": "2026-07-22",
+        "notes": "Debug Run: added an \"Open source\" button next to Start debug session. It skips booting a container and just opens the chosen revision's source tree on GitHub in a new tab, for when you only need to read the code rather than run it."
+      },
+      {
+        "version": "4.11.1",
+        "date": "2026-07-22",
+        "notes": "Debug Run no longer replaces the form when you start a session. The configuration form now stays put and each session you start appears in a scrollable \"Existing debug sessions\" list beneath it (with its live progress bar, Open and End), so you can launch several at once - extra ones queue and start as earlier sessions finish - and reconnect to or end any of them from any device."
+      },
+      {
+        "version": "4.11.0",
+        "date": "2026-07-22",
+        "notes": "Debug Run now supports Windows containers, not just Linux. Pick Linux or Windows in the dialog; the activity list adjusts to what each platform can run. A Windows session boots the Windows worker with an interactive desktop (TightVNC captures the LabVIEW IDE) and bridges it out over noVNC + a Cloudflare tunnel, the same one-click remote-desktop experience as Linux."
+      },
       {
         "version": "4.10.3",
         "date": "2026-07-23",

--- a/.github/labview/validate-catalog-source-sync.py
+++ b/.github/labview/validate-catalog-source-sync.py
@@ -4,12 +4,45 @@
 from __future__ import annotations
 
 import json
+import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 CATALOG = ROOT / ".github" / "labview-ci" / "catalog.json"
+
+# Files that exist ONLY in the tooling source repository -- the release and
+# publishing machinery. A consumer install never has them, so the configurator
+# (integrate.html), which is a CLIENT installer, classifies them as "old tooling
+# files" and deletes them. Running the configurator against this repo (or a fork
+# of it) therefore strips the repo's ability to publish at all. That is exactly
+# what happened in e9cd54b on 2026-07-30, which also downgraded catalog.json from
+# 4.12.4 to 4.11.10 and left 4.11.11-4.12.4 unpublished for two weeks.
+#
+# This list is the repo-side backstop for that class of mistake: it cannot be
+# bypassed by a stale browser tab or a hand-edited PR the way a UI check can.
+SOURCE_ONLY_FILES = [
+    ".github/labview-ci/source.json",
+    ".github/labview/promote-release.py",
+    ".github/labview/validate-catalog-source-sync.py",
+    ".github/labview/vipm/build-tooling-vipc.py",
+    ".github/pages/configure.html",
+    ".github/pages/integrate.html",
+    ".github/pages/whats-new.html",
+    ".github/workflows/build-labview-image.yml",
+    ".github/workflows/build-labview-linux-image.yml",
+    ".github/workflows/catalog-source-sync.yml",
+    ".github/workflows/copy-labview-image.yml",
+    ".github/workflows/copy-labview-linux-image.yml",
+    ".github/workflows/discover-clients.yml",
+    ".github/workflows/integrate-deploy.yml",
+    ".github/workflows/labview-ci.reusable.yml",
+    ".github/workflows/promote-release.yml",
+    ".github/workflows/release.yml",
+]
 
 REQUIRED_CUSTOM_IMAGE_WINDOWS = [
     ".github/workflows/build-labview-image.yml",
@@ -33,8 +66,64 @@ def path_exists(relpath: str) -> bool:
     return (ROOT / relpath).exists()
 
 
+SEMVER_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(text: str) -> tuple[int, int, int] | None:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)$", (text or "").strip())
+    return (int(match[1]), int(match[2]), int(match[3])) if match else None
+
+
+def highest_published_version() -> tuple[tuple[int, int, int], str] | None:
+    """Highest v<MAJOR>.<MINOR>.<PATCH> tag in this clone, or None if unknown.
+
+    Returns None when git is unavailable or no version tags are present (a
+    shallow CI checkout, or a clone fetched without tags). Callers must treat
+    None as "could not check" rather than "nothing published" -- see main().
+    """
+    try:
+        out = subprocess.run(
+            ["git", "tag", "--list", "v*.*.*"],
+            cwd=ROOT, capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+
+    best: tuple[tuple[int, int, int], str] | None = None
+    for line in out.stdout.splitlines():
+        match = SEMVER_TAG.match(line.strip())
+        if not match:
+            continue
+        parsed = (int(match[1]), int(match[2]), int(match[3]))
+        if best is None or parsed > best[0]:
+            best = (parsed, line.strip())
+    return best
+
+
 def main() -> int:
     failures: list[str] = []
+
+    # Run FIRST: everything below reads source-owned files directly, so a repo
+    # that has had its publishing machinery deleted should fail with this clear
+    # message rather than a FileNotFoundError traceback further down.
+    missing_source_files = [p for p in SOURCE_ONLY_FILES if not path_exists(p)]
+    if missing_source_files:
+        err(
+            "This repository is the LabVIEW CI tooling SOURCE, but files that only "
+            "the source repo carries have been deleted:"
+        )
+        for relpath in missing_source_files:
+            err(f"  - {relpath}")
+        err(
+            "This is the signature of running the LabVIEW CI configurator (the client "
+            "installer) against the source repo or a fork of it: it removes source-only "
+            "files as 'old tooling' and overwrites catalog.json with an older payload. "
+            "Restore these files from the last release tag instead of merging this change."
+        )
+        return 1
+
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
 
     releases = (catalog.get("history") or {}).get("releases") or []
@@ -45,6 +134,41 @@ def main() -> int:
             "catalog version must equal history.releases[0].version "
             f"({catalog.get('version')!r} != {releases[0].get('version')!r})"
         )
+
+    # The catalog version is the version of record: release.yml reads it to cut
+    # the tag and move the v<major> alias every client pins to. It must never go
+    # backwards. It regressed once (4.12.4 -> 4.11.10) and the failure was silent
+    # -- the file stayed internally consistent, so the check above still passed,
+    # while release.yml quietly stopped publishing because v4.11.10 already
+    # existed. Comparing against the tags is what makes that visible.
+    current = parse_version(catalog.get("version") or "")
+    if current is None:
+        failures.append(
+            f"catalog version {catalog.get('version')!r} is not MAJOR.MINOR.PATCH"
+        )
+    else:
+        published = highest_published_version()
+        if published is None:
+            message = (
+                "could not read version tags, so the catalog version was NOT checked "
+                "against the published releases (fetch tags: actions/checkout with "
+                "fetch-depth: 0)"
+            )
+            # Lenient for local runs on a shallow/tagless clone; strict in CI,
+            # where a silently skipped guard is how this got missed the first time.
+            if os.environ.get("GITHUB_ACTIONS") == "true":
+                failures.append(message)
+            else:
+                print(f"WARNING: {message}", file=sys.stderr)
+        elif current < published[0]:
+            failures.append(
+                f"catalog version {catalog['version']} is LOWER than the highest "
+                f"published release {published[1]}. The version of record must never "
+                "go backwards: release.yml would find the tag already present, publish "
+                "nothing, and leave the v<major> alias stranded on the newer release. "
+                f"Set version to something above {published[1].lstrip('v')} (and add a "
+                "matching history.releases[0] entry)."
+            )
 
     capabilities = catalog.get("capabilities") or []
     custom_image = next((cap for cap in capabilities if cap.get("id") == "custom-image"), None)

--- a/.github/pages/integrate.html
+++ b/.github/pages/integrate.html
@@ -2563,10 +2563,52 @@
       await proceedInstall($("repo").value.trim(), { keepSettings, deleteStale });
     }
 
+    // This configurator is a CLIENT installer. It vendors a tooling payload pinned
+    // to the chosen channel and deletes files it does not recognise as current
+    // tooling. The tooling SOURCE repo carries release machinery no client has --
+    // release.yml, promote-release.py, discover-clients.yml, these configurator
+    // pages themselves -- so pointing the installer at the source repo, or at a
+    // fork of it, strips its ability to publish AND overwrites catalog.json (the
+    // version of record) with whatever older version the channel resolves to.
+    //
+    // That is not hypothetical: on 2026-07-30 an install pinned at v4.11.10 (the
+    // beta channel head at the time) landed on a fork of the source, downgraded
+    // the catalog from 4.12.4, deleted 48 source-only files, and stalled every
+    // client release for two weeks. Refuse it, with no override -- there is no
+    // legitimate reason to install the client payload over its own source.
+    async function toolingSourceBlock(repo) {
+      const src = (canonical && canonical.repo) || SOURCE_FALLBACK.repo;
+      const norm = (s) => String(s || "").trim().toLowerCase();
+      if (norm(repo) === norm(src)) return { src, why: "is the LabVIEW CI tooling source repository" };
+      // The fork check needs the API. On a network/permission failure we fall
+      // through and allow the install: the source repo's own catalog-source-sync
+      // check is the authoritative backstop and cannot be bypassed from here.
+      let meta = null;
+      try {
+        const r = await gh(`/repos/${repo}`);
+        meta = r.ok ? await r.json() : null;
+      } catch (_) { return null; }
+      if (!meta || !meta.fork) return null;
+      const parents = [meta.parent && meta.parent.full_name, meta.source && meta.source.full_name].filter(Boolean);
+      if (parents.some(p => norm(p) === norm(src))) return { src, why: "is a fork of the LabVIEW CI tooling source repository" };
+      return null;
+    }
+
+    function toolingSourceMessage(repo, block) {
+      return `<strong>${esc(repo)}</strong> ${esc(block.why)} (<strong>${esc(block.src)}</strong>), so this installer will not run against it.` +
+        ` Installing the client payload here would delete the release machinery that publishes LabVIEW CI and roll <code>catalog.json</code> back to an older version.` +
+        ` To change the tooling itself, edit it in <strong>${esc(block.src)}</strong> and open a pull request there.` +
+        ` To try the pipeline out, point this at a separate test repository instead.`;
+    }
+
     async function installToRepo() {
       const repo = $("repo").value.trim();
       if (!repo.includes("/")) { setInsStatus("Enter your target repository (owner/name) in step 1 first.", "err"); const r = $("repo"); if (r) r.focus(); return; }
       if (!getInsTok()) { showInsTokPanel(); return; }
+      {
+        const block = await toolingSourceBlock(repo);
+        if (block) { setInsStatus(toolingSourceMessage(repo, block), "err"); return; }
+      }
       hideFlightPanel();
       installBusy(true);
       setInsStatus("Checking your repository&hellip;", null);
@@ -2577,6 +2619,12 @@
     }
 
     async function proceedInstall(repo, opts) {
+      // Hard stop at the choke point every install path funnels through
+      // (installToRepo -> continueAfterFlight, and the re-install panel's
+      // confirmReinstall), so the check above cannot be skipped by resuming an
+      // in-flight install or by a stale panel left open from an earlier repo.
+      const blocked = await toolingSourceBlock(repo);
+      if (blocked) { hideReinstallPanel(); setInsStatus(toolingSourceMessage(repo, blocked), "err"); installBusy(false); return; }
       const owner = repo.split("/")[0];
       const s = source();
       installBusy(true);

--- a/.github/workflows/catalog-source-sync.yml
+++ b/.github/workflows/catalog-source-sync.yml
@@ -1,22 +1,16 @@
 name: Catalog Source Sync
 run-name: Catalog/source sync - ${{ github.event_name == 'workflow_dispatch' && 'manual run' || github.sha }}
 
+# Deliberately NOT path-filtered. The validator now also guards against the
+# source repo's own publishing machinery being deleted, and a PR that deletes
+# those files may touch none of the paths a filter would list -- the filter is
+# the very thing that would let it through. This is a ~10s Python run, so it is
+# cheap enough to gate every pull request. Make it a REQUIRED status check on
+# main (Settings > Branches) so the guard actually blocks a merge.
 on:
   pull_request:
-    paths:
-      - '.github/labview-ci/catalog.json'
-      - '.github/labview/validate-catalog-source-sync.py'
-      - '.github/docker/**'
-      - '.github/workflows/build-labview-image.yml'
-      - '.github/workflows/catalog-source-sync.yml'
   push:
     branches: [main]
-    paths:
-      - '.github/labview-ci/catalog.json'
-      - '.github/labview/validate-catalog-source-sync.py'
-      - '.github/docker/**'
-      - '.github/workflows/build-labview-image.yml'
-      - '.github/workflows/catalog-source-sync.yml'
   workflow_dispatch:
 
 permissions:
@@ -28,5 +22,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # fetch-depth: 0 brings the tags. The validator compares the catalog
+          # version against the highest published v<major>.<minor>.<patch> tag to
+          # prove the version of record never moves backwards; without tags that
+          # check cannot run, and it fails loudly in CI rather than skipping.
+          fetch-depth: 0
       - name: Validate catalog/source sync
         run: python3 .github/labview/validate-catalog-source-sync.py

--- a/actions/dashboard/integrate.html
+++ b/actions/dashboard/integrate.html
@@ -2563,10 +2563,52 @@
       await proceedInstall($("repo").value.trim(), { keepSettings, deleteStale });
     }
 
+    // This configurator is a CLIENT installer. It vendors a tooling payload pinned
+    // to the chosen channel and deletes files it does not recognise as current
+    // tooling. The tooling SOURCE repo carries release machinery no client has --
+    // release.yml, promote-release.py, discover-clients.yml, these configurator
+    // pages themselves -- so pointing the installer at the source repo, or at a
+    // fork of it, strips its ability to publish AND overwrites catalog.json (the
+    // version of record) with whatever older version the channel resolves to.
+    //
+    // That is not hypothetical: on 2026-07-30 an install pinned at v4.11.10 (the
+    // beta channel head at the time) landed on a fork of the source, downgraded
+    // the catalog from 4.12.4, deleted 48 source-only files, and stalled every
+    // client release for two weeks. Refuse it, with no override -- there is no
+    // legitimate reason to install the client payload over its own source.
+    async function toolingSourceBlock(repo) {
+      const src = (canonical && canonical.repo) || SOURCE_FALLBACK.repo;
+      const norm = (s) => String(s || "").trim().toLowerCase();
+      if (norm(repo) === norm(src)) return { src, why: "is the LabVIEW CI tooling source repository" };
+      // The fork check needs the API. On a network/permission failure we fall
+      // through and allow the install: the source repo's own catalog-source-sync
+      // check is the authoritative backstop and cannot be bypassed from here.
+      let meta = null;
+      try {
+        const r = await gh(`/repos/${repo}`);
+        meta = r.ok ? await r.json() : null;
+      } catch (_) { return null; }
+      if (!meta || !meta.fork) return null;
+      const parents = [meta.parent && meta.parent.full_name, meta.source && meta.source.full_name].filter(Boolean);
+      if (parents.some(p => norm(p) === norm(src))) return { src, why: "is a fork of the LabVIEW CI tooling source repository" };
+      return null;
+    }
+
+    function toolingSourceMessage(repo, block) {
+      return `<strong>${esc(repo)}</strong> ${esc(block.why)} (<strong>${esc(block.src)}</strong>), so this installer will not run against it.` +
+        ` Installing the client payload here would delete the release machinery that publishes LabVIEW CI and roll <code>catalog.json</code> back to an older version.` +
+        ` To change the tooling itself, edit it in <strong>${esc(block.src)}</strong> and open a pull request there.` +
+        ` To try the pipeline out, point this at a separate test repository instead.`;
+    }
+
     async function installToRepo() {
       const repo = $("repo").value.trim();
       if (!repo.includes("/")) { setInsStatus("Enter your target repository (owner/name) in step 1 first.", "err"); const r = $("repo"); if (r) r.focus(); return; }
       if (!getInsTok()) { showInsTokPanel(); return; }
+      {
+        const block = await toolingSourceBlock(repo);
+        if (block) { setInsStatus(toolingSourceMessage(repo, block), "err"); return; }
+      }
       hideFlightPanel();
       installBusy(true);
       setInsStatus("Checking your repository&hellip;", null);
@@ -2577,6 +2619,12 @@
     }
 
     async function proceedInstall(repo, opts) {
+      // Hard stop at the choke point every install path funnels through
+      // (installToRepo -> continueAfterFlight, and the re-install panel's
+      // confirmReinstall), so the check above cannot be skipped by resuming an
+      // in-flight install or by a stale panel left open from an earlier repo.
+      const blocked = await toolingSourceBlock(repo);
+      if (blocked) { hideReinstallPanel(); setInsStatus(toolingSourceMessage(repo, blocked), "err"); installBusy(false); return; }
       const owner = repo.split("/")[0];
       const s = source();
       installBusy(true);


### PR DESCRIPTION
## What happened

`catalog.json` is the version of record — `release.yml` reads it to cut the tag and force-move the `v<major>` alias every client pins to.

On 2026-07-30, `e9cd54b` rolled it **backwards** from 4.12.4 to 4.11.10 and deleted 48 source-only files. That commit was generated by the **LabVIEW CI configurator** — the *client* installer — run against a fork of this repo. It vendored a v4.11.10 payload (the beta channel head at the time) and stripped the release machinery no client carries.

PR #43 reverted it seven minutes later, but the revert was undone by merging main back into the fork and re-merging the branch: `0163222` re-landed the downgrade and PR #44 carried it to main. The source files survived the second landing; `catalog.json` did not.

**The failure was silent.** The catalog stayed internally consistent at 4.11.10, so the existing validator passed, while `release.yml` found `v4.11.10` already tagged and published nothing:

```
version=4.11.10  tag=v4.11.10  aliases=v4,v4.11
Tag v4.11.10 already exists.
Updated release v4.11.10.
```

A green build that shipped 4.11.11 → 4.12.4 to nobody for two weeks, with the dashboard reporting 4.11.10 as "the latest version".

## Restore

`catalog.json` rebuilt from `v4.12.4` (the last good copy) with the `sbom-generation` capability re-applied on top — 29 insertions, 1 deletion against that tag.

| | before | after |
|---|---|---|
| `version` | 4.11.10 | **4.13.0** |
| `betaVersion` | 4.11.8 | 4.11.10 (restored) |
| history entries | 409 | 417 (4.11.11–4.12.4 recovered + 4.13.0) |
| capabilities | 11 | 11 (`sbom-generation` kept) |

Minor bump because SBOM Generation is a new capability. On merge, `release.yml` publishes `v4.13.0` and moves `v4`/`v4.13`, so the SBOM work, the fork-PR Pages fix and the docs expansion finally reach clients.

## Guards, in the order they fire

1. **`integrate.html`** refuses to install into the tooling source repo or any fork of it — checked at the entry point *and* at `proceedInstall`, the choke point every path funnels through. No override.
2. **`validate-catalog-source-sync.py`** fails if the catalog version is lower than the highest published `v*` tag, and fails if any source-only file has been deleted. The deletion check runs first, so a stripped repo reports that rather than a `FileNotFoundError` traceback.
3. **`catalog-source-sync.yml`** drops its path filters — a PR deleting source-only files need not touch any path a filter would list — and checks out with `fetch-depth: 0` so the tags are present. A missing-tag lookup now fails in CI instead of skipping silently.
4. **`CODEOWNERS`** on the release machinery; **`CONTRIBUTING.md`** documents the rules, including reverting a revert rather than re-merging.

## Verification

Replayed against the actual regression:

- `origin/main`'s clobbered catalog → rejected: *"catalog version 4.11.10 is LOWER than the highest published release v4.12.4"*
- `e9cd54b`'s deletions → rejected, naming each missing file
- tags unavailable → fails in CI, warns locally
- installer block → rejects the source repo, the exact fork involved, a fork-of-a-fork, and case variants; allows ordinary client repos; fails open if the API is unreadable (the repo-side check is the authoritative backstop)
- JS parses (`node --check`); validator passes on the final tree

## One manual step remains

The guards need branch protection to enforce them. On `main`, under **Settings › Branches**:

- Require a pull request before merging
- Require review from Code Owners
- Require status checks → **`Catalog Source Sync`**

Without the required check, `catalog-source-sync` reports a failure that nothing acts on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)