### PR TITLE
Let CI own the version: derive it from tags, publish every merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,13 @@
 /.github/workflows/discover-clients.yml             @elijah286
 /.github/workflows/integrate-deploy.yml             @elijah286
 
-# The guard that enforces all of the above.
+# The guard that enforces all of the above, and the machinery that derives and
+# publishes versions. Release-note fragments under notes/ are deliberately NOT
+# owned -- they are the one part of the release any contributor should be adding.
 /.github/labview/validate-catalog-source-sync.py    @elijah286
 /.github/labview/promote-release.py                 @elijah286
+/.github/labview/version.py                         @elijah286
+/.github/labview/publish-release.sh                 @elijah286
 
 # The configurator/installer pages clients are served.
 /.github/pages/integrate.html                       @elijah286

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,23 +23,43 @@ The configurator now refuses this, and `catalog-source-sync` fails the PR if the
 source-only files go missing. **To test the pipeline, install it into a separate
 scratch repository.**
 
-## `catalog.json` is the version of record
+## Never edit `catalog.json`
 
-`.github/labview-ci/catalog.json` → `version` is what `release.yml` reads to cut
-the `v<MAJOR>.<MINOR>.<PATCH>` tag and force-move the `v<MAJOR>` alias that every
-client pins to. It is release machinery, not a config file.
+`.github/labview-ci/catalog.json` → `version` is the version of record: the
+release workflow reads it to cut the `v<MAJOR>.<MINOR>.<PATCH>` tag and force-move
+the `v<MAJOR>` alias every client pins to. It is release machinery, not a config
+file, and **CI owns it**. You should never have it open.
 
-- **Never hand-edit it on a feature branch**, and never resolve a conflict in it
-  by taking your side. If your branch's copy is older than main's, take main's.
-- The version must only ever go **up**. `catalog-source-sync` compares it against
-  the highest published `v*` tag and fails the PR if it moves backwards.
-- `version` must equal `history.releases[0].version`, so a bump means adding a
-  history entry too.
-- Patch for fixes, minor for a new capability, major for a breaking change.
+Every merge to main is published automatically. CI derives the next version from
+the highest published **tag** — never from the file — so a stale or conflicted
+catalog cannot roll the version backwards. That's deliberate: on 2026-07-30 a
+hand-edited copy took the version from 4.12.4 to 4.11.10 and stalled every client
+release for two weeks.
 
-A downgrade fails quietly if it gets through: `release.yml` finds the tag already
-exists, publishes nothing, and leaves the alias stranded on the newer release. It
-looks like a green build.
+What you supply instead, both optional:
+
+**A release note.** Drop a `.md` file in `.github/labview-ci/notes/` describing
+your change in prose, as a client would read it. One file per PR, so two PRs can
+never conflict. CI folds pending fragments into the release and deletes them. See
+[the notes README](labview-ci/notes/README.md). Forget one and the release still
+happens, falling back to your PR title.
+
+**A bump level.** Label the PR `release:minor` for a new capability or
+`release:major` for a breaking change. No label means patch, which is right most
+of the time. Major moves `@v<major>`, so it should be rare.
+
+To land something without publishing, put `[skip release]` in the merge commit
+message — but use it sparingly. Everything being published is what makes
+retroactive promotion to beta and stable work.
+
+## Channels, not version numbers, carry risk
+
+Publishing is automatic and unconditional. Deciding a version is *good* is a
+separate, manual, retroactive act: `promote-release.yml` moves the rolling
+`stable` and `beta` tags to an already-published release. Nothing is rebuilt.
+
+So don't agonise over a version number — it's a counter. The thing that decides
+what a client actually receives is which release the channel points at.
 
 ## Reverts
 

--- a/.github/labview-ci/notes/README.md
+++ b/.github/labview-ci/notes/README.md
@@ -1,0 +1,56 @@
+# Release-note fragments
+
+Drop one `.md` file here per pull request describing what changed, in the voice of
+the release notes clients read on the What's New page.
+
+```
+.github/labview-ci/notes/sbom-vipm-version-detect.md
+```
+
+Name it after the change, not the PR number — a descriptive name is readable in a
+diff and still can't collide with anyone else's.
+
+On merge, the Release workflow folds every pending fragment into one catalog
+history entry, publishes the version, and deletes the fragments it used. Nothing
+here is permanent; the catalog is where notes end up.
+
+## Why fragments instead of editing the catalog
+
+`catalog.json` is the version of record — the release workflow reads it to cut the
+tag and move the `v<major>` alias every client pins to. When contributors edited it
+directly, two branches touching it conflicted constantly, and on 2026-07-30 a
+stale copy silently rolled the version back from 4.12.4 to 4.11.10 and stopped
+client releases for two weeks.
+
+One file per PR means two PRs can never conflict, and nothing a contributor writes
+can change the version of record.
+
+## Writing a good fragment
+
+Plain prose, no heading, no bullet — it becomes one entry in a list clients read.
+Say what changed and what it means for them:
+
+> VI Analyzer reports now embed each VI's rendered front panel and block diagram
+> inline, so findings sit beside the actual code rather than a bare list of VI
+> names.
+
+Whitespace is collapsed, so wrap however you like. A trailing period is added if
+you leave it off.
+
+## Choosing the version bump
+
+Add a label to the PR:
+
+| Label | Effect | Use for |
+|---|---|---|
+| *(none)* | patch | Fixes, tweaks, docs — the default |
+| `release:minor` | minor | A new capability or a user-visible feature |
+| `release:major` | major | A breaking change (this moves `@v<major>`, so it's rare) |
+
+## Skipping a release
+
+Put `[skip release]` in the merge commit message. Use it sparingly — every change
+being published is what makes retroactive promotion to beta and stable work.
+
+If you forget a fragment entirely, the release still happens and falls back to the
+pull request title. That's a worse note, not a failed merge.

--- a/.github/labview-ci/notes/ci-owned-versioning.md
+++ b/.github/labview-ci/notes/ci-owned-versioning.md
@@ -1,0 +1,8 @@
+Releases are now produced by CI rather than by hand. Every merge to main is
+published automatically, with the next version derived from the highest published
+tag instead of from catalog.json, so a stale or conflicted catalog can no longer
+roll the version of record backwards. Contributors add a release-note fragment and
+an optional release:minor / release:major label; nobody edits the catalog. The
+promote-release button now tags and publishes inside its own run, fixing a
+long-standing bug where promotions bumped the catalog to a version that was never
+tagged and never moved the rolling stable or beta tag.

--- a/.github/labview/promote-release.py
+++ b/.github/labview/promote-release.py
@@ -23,6 +23,7 @@ published release, so a workflow can gate on it.
 import argparse
 import datetime
 import json
+import os
 import sys
 
 CATALOG = ".github/labview-ci/catalog.json"
@@ -32,12 +33,38 @@ CATALOG = ".github/labview-ci/catalog.json"
 _TOP_ORDER = ["schemaVersion", "version", "stableVersion", "betaVersion"]
 
 
-def _bump_patch(ver):
-    parts = ver.split(".")
-    if len(parts) != 3 or not all(p.isdigit() for p in parts):
-        raise SystemExit("::error::catalog version %r is not MAJOR.MINOR.PATCH" % ver)
-    parts[2] = str(int(parts[2]) + 1)
-    return ".".join(parts)
+def _next_patch_from_tags():
+    """Next patch version, derived from the published TAGS -- never from the file.
+
+    This used to read cat["version"] and add one. That inherits whatever the
+    catalog happens to say, so promoting against a regressed catalog would compute
+    a version that already exists and collide on the tag -- the same failure that
+    silently stopped releases after the 2026-07-30 downgrade. The tags are the
+    only authority on what has actually been published.
+    """
+    import re
+    import subprocess
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    try:
+        out = subprocess.run(
+            ["git", "tag", "--list", "v*.*.*"],
+            cwd=root, capture_output=True, text=True, timeout=30, check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SystemExit(
+            "::error::could not read git tags (%s); check out with fetch-depth: 0" % exc
+        )
+    pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+    versions = [
+        (int(m[1]), int(m[2]), int(m[3]))
+        for m in (pattern.match(l.strip()) for l in out.stdout.splitlines())
+        if m
+    ]
+    if not versions:
+        raise SystemExit("::error::no v<MAJOR>.<MINOR>.<PATCH> tags found")
+    major, minor, patch = max(versions)
+    return "%d.%d.%d" % (major, minor, patch + 1)
 
 
 def _releases(cat):
@@ -86,7 +113,7 @@ def main(argv=None):
         )
 
     top = str(cat.get("version", ""))
-    new_version = _bump_patch(top)
+    new_version = _next_patch_from_tags()
     date = args.date or datetime.datetime.utcnow().strftime("%Y-%m-%d")
 
     if args.unpromote:

--- a/.github/labview/publish-release.sh
+++ b/.github/labview/publish-release.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Publish the version currently in the catalog: immutable tag, moving aliases,
+# rolling channel tags, GitHub Release.
+#
+# This used to live inline in release.yml, which meant it only ever ran when a
+# push to main touched catalog.json. Pushes made with the built-in GITHUB_TOKEN
+# do not trigger workflows, so every catalog bump written by promote-release.yml
+# was announced in the catalog and then never tagged: 4.10.2, 4.10.3 and 4.11.11
+# are all phantom versions created that way. Extracting it here lets each workflow
+# publish inside its own run, where no trigger is involved.
+#
+# Idempotent: an existing tag is left alone and its release notes refreshed.
+#
+# Environment:
+#   GH_TOKEN        required, for gh release create/edit
+#   FORCE_ALIASES   optional, "true" re-points v<major>/v<major>.<minor> even when
+#                   the tag already existed
+set -euo pipefail
+
+CAT=.github/labview-ci/catalog.json
+cat_get() { python3 -c "import json,sys;print(json.load(open('$CAT')).get(sys.argv[1],'') or '')" "$1"; }
+
+VER=$(cat_get version)
+case "$VER" in
+  [0-9]*.[0-9]*.[0-9]*) : ;;
+  *) echo "::error::catalog version '$VER' is not MAJOR.MINOR.PATCH"; exit 1 ;;
+esac
+
+MAJOR=${VER%%.*}; REST=${VER#*.}; MINOR=${REST%%.*}
+TAG="v${VER}"; MAJOR_ALIAS="v${MAJOR}"; MINOR_ALIAS="v${MAJOR}.${MINOR}"
+echo "version=$VER  tag=$TAG  aliases=$MAJOR_ALIAS,$MINOR_ALIAS"
+
+git config user.name  "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+NEW_TAG=false
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Tag ${TAG} already exists."
+else
+  git tag -a "${TAG}" -m "LabVIEW CI ${TAG}"
+  git push origin "${TAG}"
+  NEW_TAG=true
+  echo "Created tag ${TAG}."
+fi
+
+# The moving-alias contract: @v<major> always points at the latest release.
+if [ "$NEW_TAG" = "true" ] || [ "${FORCE_ALIASES:-false}" = "true" ]; then
+  for A in "$MAJOR_ALIAS" "$MINOR_ALIAS"; do
+    git tag -f "$A" "$TAG^{}"
+    git push -f origin "$A"
+    echo "Moved alias ${A} -> ${TAG}."
+  done
+fi
+
+# Rolling channel tags. `stableVersion` / `betaVersion` are set by
+# promote-release.py (the owner's "Mark as stable release" button) and are absent
+# until the first promotion, in which case this is a no-op. Only moves a tag when
+# it is not already where it belongs.
+move_channel() {
+  local tier="$1" want_ver="$2"
+  [ -n "$want_ver" ] || return 0
+  if ! git rev-parse -q --verify "refs/tags/v${want_ver}^{}" >/dev/null; then
+    echo "::warning::${tier}Version ${want_ver} has no v${want_ver} tag yet; leaving '${tier}' unchanged."
+    return 0
+  fi
+  local want have
+  want=$(git rev-parse "v${want_ver}^{}")
+  have=$(git rev-parse -q --verify "refs/tags/${tier}^{}" 2>/dev/null || echo "")
+  if [ "$want" != "$have" ]; then
+    git tag -f "$tier" "v${want_ver}^{}"
+    git push -f origin "$tier"
+    echo "Moved rolling '${tier}' tag -> v${want_ver}."
+  else
+    echo "Rolling '${tier}' tag already at v${want_ver}."
+  fi
+}
+move_channel stable "$(cat_get stableVersion)"
+move_channel beta   "$(cat_get betaVersion)"
+
+# Release notes come from the catalog's newest history entry.
+python3 - "$CAT" > /tmp/relnotes.md <<'PY'
+import json, sys
+c = json.load(open(sys.argv[1], encoding='utf-8'))
+rels = (c.get('history') or {}).get('releases') or []
+rel = rels[0] if rels else {}
+out = []
+if rel.get('summary'): out += [rel['summary'], '']
+if rel.get('notes'):   out += [rel['notes'], '']
+for h in rel.get('highlights') or []: out.append(f'- {h}')
+out += ['', 'Consumers pinned at the major alias (e.g. `@v%s`) receive this automatically.'
+        % (str(c.get('version','1')).split('.')[0])]
+open('/tmp/reltitle.txt','w').write(rel.get('title') or f"LabVIEW CI {c.get('version','')}")
+print('\n'.join(out))
+PY
+
+if gh release view "${TAG}" >/dev/null 2>&1; then
+  gh release edit "${TAG}" --title "$(cat /tmp/reltitle.txt)" --notes-file /tmp/relnotes.md
+  echo "Updated release ${TAG}."
+else
+  gh release create "${TAG}" --target "$(git rev-parse HEAD)" \
+    --title "$(cat /tmp/reltitle.txt)" --notes-file /tmp/relnotes.md
+  echo "Published release ${TAG}."
+fi
+
+{
+  echo "## Released ${TAG}"
+  echo ""
+  echo "- Immutable tag \`${TAG}\` published."
+  echo "- Aliases \`${MAJOR_ALIAS}\` and \`${MINOR_ALIAS}\` now point at \`${TAG}\`."
+  echo ""
+  echo "Consumers pinned at \`@${MAJOR_ALIAS}\` get this update automatically — no token, no action."
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/labview/validate-catalog-source-sync.py
+++ b/.github/labview/validate-catalog-source-sync.py
@@ -74,6 +74,23 @@ def parse_version(text: str) -> tuple[int, int, int] | None:
     return (int(match[1]), int(match[2]), int(match[3])) if match else None
 
 
+def published_tag_names() -> set[str]:
+    """Every published version as a bare string ("4.12.4"), empty if tags are unavailable."""
+    try:
+        out = subprocess.run(
+            ["git", "tag", "--list", "v*.*.*"],
+            cwd=ROOT, capture_output=True, text=True, timeout=30, check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    names = set()
+    for line in out.stdout.splitlines():
+        tag = line.strip()
+        if SEMVER_TAG.match(tag):
+            names.add(tag[1:])
+    return names
+
+
 def highest_published_version() -> tuple[tuple[int, int, int], str] | None:
     """Highest v<MAJOR>.<MINOR>.<PATCH> tag in this clone, or None if unknown.
 
@@ -168,6 +185,27 @@ def main() -> int:
                 "nothing, and leave the v<major> alias stranded on the newer release. "
                 f"Set version to something above {published[1].lstrip('v')} (and add a "
                 "matching history.releases[0] entry)."
+            )
+
+    # Channel pointers must name a version that was actually PUBLISHED, not merely
+    # written into the catalog. promote-release.yml used to bump the catalog and
+    # rely on release.yml to tag it, but GITHUB_TOKEN pushes do not trigger
+    # workflows -- so 4.10.2, 4.10.3 and 4.11.11 were announced and never tagged,
+    # and the `beta` tag sat on v4.11.8 for three weeks while betaVersion said
+    # 4.11.10. Pointing a channel at an untagged version strands every client on
+    # that channel, so it is worth failing over.
+    tagged = published_tag_names()
+    for tier in ("stableVersion", "betaVersion"):
+        pointer = (catalog.get(tier) or "").strip()
+        if not pointer:
+            continue
+        if parse_version(pointer) is None:
+            failures.append(f"{tier} {pointer!r} is not MAJOR.MINOR.PATCH")
+        elif tagged and pointer not in tagged:
+            failures.append(
+                f"{tier} points at {pointer}, which has no v{pointer} tag. A channel "
+                "must name a published release; clients on that channel would resolve "
+                "to a version that does not exist."
             )
 
     capabilities = catalog.get("capabilities") or []

--- a/.github/labview/version.py
+++ b/.github/labview/version.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Derive the next LabVIEW CI version from the published tags and write the catalog.
+
+The catalog version is the version of record: the release workflow reads it to cut
+the tag and force-move the v<major> alias every client pins to. It used to be
+hand-edited on feature branches, which is how it was silently rolled back from
+4.12.4 to 4.11.10 on 2026-07-30 (e9cd54b): a stale copy overwrote a newer one, the
+file stayed internally consistent so nothing complained, and every client release
+stalled for two weeks behind a tag that already existed.
+
+So nothing here derives the next version from the file. The published tags are the
+only source of truth -- whatever the catalog currently says, the next version is
+always above every v<MAJOR>.<MINOR>.<PATCH> tag that exists. A stale, regressed or
+conflicted catalog therefore cannot produce a colliding or backwards version; the
+worst it can do is lose a release note, which is visible and recoverable.
+
+Release notes come from fragment files under .github/labview-ci/notes/ (one per
+pull request, so two PRs can never conflict in the same file). `apply` folds them
+into a single history entry and prints the fragments it consumed so the caller can
+delete them.
+
+Usage:
+    version.py next  --bump minor
+    version.py apply --bump minor [--date YYYY-MM-DD] [--fallback-note "..."]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG = ROOT / ".github" / "labview-ci" / "catalog.json"
+NOTES_DIR = ROOT / ".github" / "labview-ci" / "notes"
+
+SEMVER_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+LEVELS = ("major", "minor", "patch")
+
+
+def die(message: str) -> "None":
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def published_versions() -> list[tuple[int, int, int]]:
+    """Every released version, read from the tags rather than from the catalog."""
+    try:
+        out = subprocess.run(
+            ["git", "tag", "--list", "v*.*.*"],
+            cwd=ROOT, capture_output=True, text=True, timeout=30, check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        die(f"could not read git tags ({exc}); check out with fetch-depth: 0")
+    found = []
+    for line in out.stdout.splitlines():
+        match = SEMVER_TAG.match(line.strip())
+        if match:
+            found.append((int(match[1]), int(match[2]), int(match[3])))
+    return found
+
+
+def next_version(bump: str) -> str:
+    versions = published_versions()
+    if not versions:
+        die("no v<MAJOR>.<MINOR>.<PATCH> tags found; refusing to guess a starting version")
+    major, minor, patch = max(versions)
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def read_fragments() -> tuple[list[Path], str]:
+    """Collect release-note fragments, oldest filename first for a stable order."""
+    if not NOTES_DIR.is_dir():
+        return [], ""
+    paths = sorted(p for p in NOTES_DIR.iterdir() if p.suffix.lower() == ".md" and p.name != "README.md")
+    chunks = []
+    used = []
+    for path in paths:
+        text = " ".join(path.read_text(encoding="utf-8").split()).strip()
+        if not text:
+            continue
+        chunks.append(text if text.endswith((".", "!", "?")) else text + ".")
+        used.append(path)
+    return used, " ".join(chunks)
+
+
+def write_catalog(version: str, date: str, notes: str) -> None:
+    """Surgically edit the catalog text.
+
+    Deliberately NOT json.dump: the file stores each release as one compact line,
+    and re-serialising reflows all 417 of them into a 4,000-line diff that buries
+    the actual change and conflicts with every other branch. Two targeted string
+    edits keep the diff to the two lines that really changed.
+    """
+    text = CATALOG.read_text(encoding="utf-8")
+    catalog = json.loads(text)
+
+    current = str(catalog.get("version", ""))
+    old_line = f'\n  "version": "{current}",\n'
+    if text.count(old_line) != 1:
+        die(f'could not locate a unique top-level "version": "{current}" line in the catalog')
+    text = text.replace(old_line, f'\n  "version": "{version}",\n')
+
+    entry = "      " + json.dumps(
+        {"version": version, "date": date, "notes": notes}, ensure_ascii=False
+    ) + ",\n"
+    anchor = '    "releases": [\n'
+    if text.count(anchor) != 1:
+        die('could not locate a unique history.releases array in the catalog')
+    index = text.index(anchor) + len(anchor)
+    text = text[:index] + entry + text[index:]
+
+    # Prove the result before it lands: valid JSON, and the invariant the
+    # validator and the release workflow both depend on.
+    parsed = json.loads(text)
+    releases = (parsed.get("history") or {}).get("releases") or []
+    if parsed.get("version") != version:
+        die("post-write check failed: top-level version did not update")
+    if not releases or releases[0].get("version") != version:
+        die("post-write check failed: history.releases[0] is not the new version")
+
+    CATALOG.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_next = sub.add_parser("next", help="print the next version derived from the tags")
+    p_next.add_argument("--bump", choices=LEVELS, default="patch")
+
+    p_apply = sub.add_parser("apply", help="write the next version + release notes into the catalog")
+    p_apply.add_argument("--bump", choices=LEVELS, default="patch")
+    p_apply.add_argument("--date", default="")
+    p_apply.add_argument("--fallback-note", default="")
+
+    args = parser.parse_args()
+    version = next_version(args.bump)
+
+    if args.command == "next":
+        print(version)
+        return 0
+
+    used, notes = read_fragments()
+    if not notes:
+        notes = " ".join((args.fallback_note or "").split()).strip()
+    if not notes:
+        die(
+            "no release note: add a fragment under .github/labview-ci/notes/ "
+            "or pass --fallback-note"
+        )
+
+    date = args.date or datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+    write_catalog(version, date, notes)
+
+    print(f"version={version}")
+    print(f"consumed={len(used)}")
+    for path in used:
+        print(f"fragment={path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -97,7 +97,7 @@ jobs:
           NEWVER=$(python3 -c "import json;print(json.load(open('$CAT'))['version'])")
           STABLE=$(python3 -c "import json;print(json.load(open('$CAT')).get('stableVersion',''))")
           git add "$CAT"
-          git commit -m "Release channel: stable=${STABLE:-none} (catalog ${NEWVER})"
+          git commit -m "Release channel: stable=${STABLE:-none} (catalog ${NEWVER}) [skip release]"
           # The default branch is hot; rebase-and-retry a few times on a non-FF push.
           for i in 1 2 3 4 5; do
             if git push origin "HEAD:${GITHUB_REF_NAME}"; then echo "pushed"; exit 0; fi
@@ -108,14 +108,28 @@ jobs:
           done
           echo "::error::could not push the promotion after retries"; exit 1
 
+      # Publish INSIDE this run. This step used to be absent: the job pushed the
+      # catalog with the built-in GITHUB_TOKEN and relied on release.yml noticing,
+      # but GITHUB_TOKEN pushes do not trigger workflows. So every promotion bumped
+      # the catalog to a version that was never tagged and never released --
+      # 4.10.2, 4.10.3 and 4.11.11 are all phantoms created exactly this way, and
+      # the rolling tag never moved either (the `beta` tag sat on v4.11.8 for
+      # three weeks while betaVersion said 4.11.10).
+      - name: Tag, move the channel tag, publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/labview/publish-release.sh
+
       - name: Summary
         if: always()
         run: |
           CAT=.github/labview-ci/catalog.json
           STABLE=$(python3 -c "import json;print(json.load(open('$CAT')).get('stableVersion',''))" 2>/dev/null || echo "")
+          BETA=$(python3 -c "import json;print(json.load(open('$CAT')).get('betaVersion',''))" 2>/dev/null || echo "")
           {
             echo "## Release channel updated"
             echo ""
             echo "- Stable version is now: \`${STABLE:-none}\`"
-            echo "- release.yml will move the rolling \`stable\` tag to the blessed commit."
+            echo "- Beta version is now: \`${BETA:-none}\`"
+            echo "- The rolling tag was moved in this run."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,44 @@
-# Publish a release when the catalog version changes.
+# Version and publish every change that lands on main.
 #
-# This is what makes the TOKEN-FREE update path work for clients: a consumer pins
-# the reusable workflow / actions at the major alias (e.g. @v1) and, optionally,
-# runs Dependabot. When this repo publishes a new version, this workflow:
-#   1. creates the immutable tag  v<MAJOR>.<MINOR>.<PATCH>  + a GitHub Release, and
-#   2. force-moves the major alias  v<MAJOR>  and minor alias  v<MAJOR>.<MINOR>
-#      to the released commit.
-# So every consumer pinned at @v1 receives non-breaking improvements automatically
-# (zero changes in their repo, no token), and Dependabot can also open a reviewable
-# PR to a specific version. Creating tags/releases uses the built-in GITHUB_TOKEN —
-# no Personal Access Token is involved (a tag is a ref, not a workflow-file edit).
+# The model: publish everything, bless selectively, pin by channel. Every merge
+# becomes an immutable v<MAJOR>.<MINOR>.<PATCH> tag and a GitHub Release; which of
+# those releases is *good* is decided later and separately, by promote-release.yml
+# moving the rolling `stable` / `beta` tags.
+#
+# Nobody edits catalog.json. The next version is derived from the published TAGS,
+# never from the file, so a stale or conflicted catalog cannot roll the version of
+# record backwards -- which is exactly what happened on 2026-07-30 (e9cd54b), when
+# a hand-edited copy took the version from 4.12.4 to 4.11.10 and stalled every
+# client release for two weeks behind a tag that already existed.
+#
+# Contributors supply only two things, both optional:
+#   * a release-note fragment in .github/labview-ci/notes/ (falls back to the PR
+#     title, so forgetting one degrades gracefully instead of failing the merge)
+#   * a release:major / release:minor label on the PR (defaults to patch)
+#
+# Bumping and publishing happen in ONE run on purpose. Pushes made with the
+# built-in GITHUB_TOKEN do not trigger workflows, so a job that commits the
+# catalog and expects another workflow to notice publishes nothing -- the bug that
+# left 4.10.2, 4.10.3 and 4.11.11 in the catalog and never tagged.
 name: Release
 run-name: Release LabVIEW CI - ${{ github.event_name == 'workflow_dispatch' && 'manual run' || github.sha }}
 
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/labview-ci/catalog.json'
   workflow_dispatch:
     inputs:
+      bump:
+        description: 'Which part of the version to increment'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      note:
+        description: 'Release note (used when no fragment files are pending)'
+        type: string
+        required: false
       move_aliases:
-        description: 'Re-point the v<major> / v<major>.<minor> aliases at the current version even if the tag already exists'
+        description: 'Re-point v<major> / v<major>.<minor> even if the tag already exists'
         type: boolean
         default: false
 
@@ -30,11 +47,17 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write   # create tags + GitHub Releases (built-in token; no PAT)
+  contents: write   # tags, releases, and the catalog commit (built-in token; no PAT)
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Skip the bot's own catalog commits (belt and braces -- GITHUB_TOKEN pushes
+    # do not trigger workflows anyway) and honour an explicit opt-out.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!contains(github.event.head_commit.message, '[skip release]') &&
+       github.event.head_commit.author.name != 'github-actions[bot]')
     steps:
       - name: Checkout (full history + tags)
         uses: actions/checkout@v5
@@ -44,115 +67,96 @@ jobs:
       - name: Validate catalog/source sync
         run: python3 .github/labview/validate-catalog-source-sync.py
 
-      - name: Tag the version and move the major/minor aliases
+      - name: Decide the bump level and the fallback note
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_BUMP: ${{ inputs.bump }}
+          DISPATCH_NOTE: ${{ inputs.note }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          BUMP="${DISPATCH_BUMP:-}"
+          NOTE="${DISPATCH_NOTE:-}"
+
+          if [ -z "$BUMP" ]; then
+            # A merged PR carries the intent: its labels choose the bump level and
+            # its title is the fallback note when no fragment was added.
+            PR=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+                   --jq '.[0] | {labels:[.labels[].name], title:.title}' 2>/dev/null || echo "")
+            if [ -n "$PR" ]; then
+              LABELS=$(printf '%s' "$PR" | python3 -c "import json,sys;print(' '.join(json.load(sys.stdin)['labels']))" 2>/dev/null || echo "")
+              [ -z "$NOTE" ] && NOTE=$(printf '%s' "$PR" | python3 -c "import json,sys;print(json.load(sys.stdin)['title'])" 2>/dev/null || echo "")
+              case " $LABELS " in
+                *" release:major "*) BUMP=major ;;
+                *" release:minor "*) BUMP=minor ;;
+                *" release:patch "*) BUMP=patch ;;
+              esac
+            fi
+          fi
+
+          # Direct pushes to main have no PR, so fall back to the commit message.
+          if [ -z "$BUMP" ]; then
+            case "$COMMIT_MSG" in
+              *"[major]"*) BUMP=major ;;
+              *"[minor]"*) BUMP=minor ;;
+              *)           BUMP=patch ;;
+            esac
+          fi
+          [ -n "$NOTE" ] || NOTE=$(printf '%s' "${COMMIT_MSG:-}" | head -1)
+
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          { echo "note<<EOF"; printf '%s\n' "$NOTE"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          echo "Bump level: $BUMP"
+          echo "Fallback note: $NOTE"
+
+      - name: Write the next version into the catalog
+        id: apply
+        env:
+          # Via env, never interpolated into the script: the fallback note is a
+          # pull-request title, which anyone opening a fork PR controls. Inlined
+          # as ${{ }} it would be shell-injectable.
+          BUMP: ${{ steps.plan.outputs.bump }}
+          NOTE: ${{ steps.plan.outputs.note }}
+        run: |
+          set -euo pipefail
+          python3 .github/labview/version.py apply --bump "$BUMP" --fallback-note "$NOTE" | tee /tmp/apply.txt
+          grep '^version=' /tmp/apply.txt >> "$GITHUB_OUTPUT"
+          # Fragments are consumed by this release. Deleting them on disk is
+          # enough -- the commit step stages the notes directory with `git add -A`.
+          grep '^fragment=' /tmp/apply.txt | cut -d= -f2- | while read -r f; do
+            [ -n "$f" ] && rm -f "$f"
+          done
+
+      - name: Re-validate before committing
+        run: python3 .github/labview/validate-catalog-source-sync.py
+
+      - name: Commit the catalog to main
+        env:
+          VERSION: ${{ steps.apply.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A .github/labview-ci/catalog.json .github/labview-ci/notes
+          if git diff --cached --quiet; then
+            echo "::error::version.py produced no catalog change"; exit 1
+          fi
+          git commit -m "Release ${VERSION} [skip release]"
+          # main is hot: another merge may land between checkout and push.
+          # Rebasing is safe because this commit only touches the catalog and the
+          # consumed note fragments.
+          for i in 1 2 3 4 5; do
+            if git push origin "HEAD:${GITHUB_REF_NAME}"; then echo "pushed"; exit 0; fi
+            echo "push rejected (attempt $i); rebasing onto the latest ${GITHUB_REF_NAME}"
+            git fetch origin "${GITHUB_REF_NAME}"
+            git rebase "origin/${GITHUB_REF_NAME}" || { echo "::error::rebase conflict on the catalog"; exit 1; }
+            sleep 3
+          done
+          echo "::error::could not push the catalog after retries"; exit 1
+
+      - name: Tag, move aliases, publish the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_ALIASES: ${{ inputs.move_aliases }}
-        run: |
-          set -euo pipefail
-          CAT=.github/labview-ci/catalog.json
-          VER=$(python3 -c "import json;print(json.load(open('$CAT'))['version'])")
-          case "$VER" in
-            [0-9]*.[0-9]*.[0-9]*) : ;;
-            *) echo "::error::catalog version '$VER' is not MAJOR.MINOR.PATCH"; exit 1 ;;
-          esac
-          MAJOR=${VER%%.*}; REST=${VER#*.}; MINOR=${REST%%.*}
-          TAG="v${VER}"; MAJOR_ALIAS="v${MAJOR}"; MINOR_ALIAS="v${MAJOR}.${MINOR}"
-          echo "version=$VER  tag=$TAG  aliases=$MAJOR_ALIAS,$MINOR_ALIAS"
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          NEW_TAG=false
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "Tag ${TAG} already exists."
-          else
-            git tag -a "${TAG}" -m "LabVIEW CI ${TAG}"
-            git push origin "${TAG}"
-            NEW_TAG=true
-            echo "Created tag ${TAG}."
-          fi
-
-          # Move the major + minor aliases to this commit (the moving-alias contract:
-          # @v1 always points at the latest non-breaking release).
-          if [ "$NEW_TAG" = "true" ] || [ "${FORCE_ALIASES}" = "true" ]; then
-            for A in "$MAJOR_ALIAS" "$MINOR_ALIAS"; do
-              git tag -f "$A" "$TAG^{}"
-              git push -f origin "$A"
-              echo "Moved alias ${A} -> ${TAG}."
-            done
-          fi
-
-          # Release channel: force-move the rolling `stable` tag to the blessed
-          # release. `stableVersion` is set by the promote-release workflow (the
-          # owner's "Mark as stable release" button); it's absent until the first
-          # promotion, in which case this is a no-op. Idempotent: only moves the
-          # tag when it isn't already at v<stableVersion>.
-          STABLE=$(python3 -c "import json;print(json.load(open('$CAT')).get('stableVersion',''))")
-          if [ -n "$STABLE" ]; then
-            if git rev-parse -q --verify "refs/tags/v${STABLE}^{}" >/dev/null; then
-              WANT=$(git rev-parse "v${STABLE}^{}")
-              HAVE=$(git rev-parse -q --verify "refs/tags/stable^{}" 2>/dev/null || echo "")
-              if [ "$WANT" != "$HAVE" ]; then
-                git tag -f stable "v${STABLE}^{}"
-                git push -f origin stable
-                echo "Moved rolling 'stable' tag -> v${STABLE}."
-              else
-                echo "Rolling 'stable' tag already at v${STABLE}."
-              fi
-            else
-              echo "::warning::stableVersion ${STABLE} has no v${STABLE} tag yet; leaving 'stable' unchanged."
-            fi
-          fi
-
-          # Same for the rolling `beta` tag (the release-candidate channel), driven
-          # by `betaVersion`. Absent until a beta is marked -> no-op.
-          BETA=$(python3 -c "import json;print(json.load(open('$CAT')).get('betaVersion',''))")
-          if [ -n "$BETA" ]; then
-            if git rev-parse -q --verify "refs/tags/v${BETA}^{}" >/dev/null; then
-              WANTB=$(git rev-parse "v${BETA}^{}")
-              HAVEB=$(git rev-parse -q --verify "refs/tags/beta^{}" 2>/dev/null || echo "")
-              if [ "$WANTB" != "$HAVEB" ]; then
-                git tag -f beta "v${BETA}^{}"
-                git push -f origin beta
-                echo "Moved rolling 'beta' tag -> v${BETA}."
-              else
-                echo "Rolling 'beta' tag already at v${BETA}."
-              fi
-            else
-              echo "::warning::betaVersion ${BETA} has no v${BETA} tag yet; leaving 'beta' unchanged."
-            fi
-          fi
-
-          # Build release notes from the catalog's newest history entry.
-          python3 - "$CAT" > /tmp/relnotes.md <<'PY'
-          import json, sys
-          c = json.load(open(sys.argv[1], encoding='utf-8'))
-          rels = (c.get('history') or {}).get('releases') or []
-          rel = rels[0] if rels else {}
-          out = []
-          if rel.get('summary'): out += [rel['summary'], '']
-          for h in rel.get('highlights') or []: out.append(f'- {h}')
-          out += ['', 'Consumers pinned at the major alias (e.g. `@v%s`) receive this automatically.'
-                  % (str(c.get('version','1')).split('.')[0])]
-          open('/tmp/reltitle.txt','w').write(rel.get('title') or f"LabVIEW CI {c.get('version','')}")
-          print('\n'.join(out))
-          PY
-
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release edit "${TAG}" --title "$(cat /tmp/reltitle.txt)" --notes-file /tmp/relnotes.md
-            echo "Updated release ${TAG}."
-          else
-            gh release create "${TAG}" --target "$GITHUB_SHA" \
-              --title "$(cat /tmp/reltitle.txt)" --notes-file /tmp/relnotes.md
-            echo "Published release ${TAG}."
-          fi
-
-          {
-            echo "## Released ${TAG}"
-            echo ""
-            echo "- Immutable tag \`${TAG}\` published."
-            echo "- Aliases \`${MAJOR_ALIAS}\` and \`${MINOR_ALIAS}\` now point at \`${TAG}\`."
-            echo ""
-            echo "Consumers pinned at \`@${MAJOR_ALIAS}\` get this update automatically — no token, no action."
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: bash .github/labview/publish-release.sh


### PR DESCRIPTION
Implements the model from the release-management review: **publish everything, bless selectively, pin by channel.** This PR does the first half — publishing becomes automatic and unconditional, and stops depending on anyone's discipline.

## What changes for contributors

Nobody edits `catalog.json` again. Instead:

- **A release note** — drop a `.md` file in `.github/labview-ci/notes/`. One file per PR, so two PRs can never conflict over release notes. Forget one and the release still happens, falling back to your PR title.
- **A bump level** — label the PR `release:minor` or `release:major`. No label means patch.

`[skip release]` in the merge commit opts out.

## The core guarantee

The next version comes from the highest published **tag**, never from the file.

That's the whole point. On 2026-07-30 a hand-edited catalog took the version from 4.12.4 to 4.11.10 — internally consistent, so nothing complained — and `release.yml` then found `v4.11.10` already tagged and published nothing for two weeks.

Verified by sabotaging `catalog.json` to exactly that regressed state:

```
catalog sabotaged to 4.11.10 (the exact 2026-07-30 regression)
version=4.13.1
VERDICT: forward, ignores the regressed file
```

A stale, conflicted or maliciously-edited catalog can now cost you a release *note*. It cannot cost you a release.

## A second bug this fixes

Bumping and publishing now happen in **one run**, which closes something older and quieter.

Pushes made with the built-in `GITHUB_TOKEN` do not trigger workflows. So `promote-release.yml` committed its catalog bump and waited for `release.yml` to notice — which never happened, not once:

| Catalog version | Created by | Tagged? |
|---|---|---|
| 4.11.11 | "Mark v4.11.10 as beta" | **never** |
| 4.10.3 | "Promote v4.10.0 to stable" | **never** |
| 4.10.2 | "Promote v4.10.0 to stable" | **never** |

Every version the promote button ever produced was a phantom, and the rolling tag never moved either — which is why `beta` sat on v4.11.8 for three weeks while `betaVersion` said 4.11.10. The publish step is now extracted to `publish-release.sh` and called by both workflows inside their own run.

## Contents

| File | |
|---|---|
| `version.py` | `next` / `apply`, tag-derived. Edits the catalog surgically so a release is a **2-line diff**, not a reflow of all 417 history entries |
| `publish-release.sh` | Tag, aliases, rolling channel tags, GitHub Release — shared by both workflows |
| `release.yml` | Runs on every push to main; decides bump, applies, commits, publishes |
| `promote-release.yml` | Now publishes in-run; no longer produces phantoms |
| `promote-release.py` | Derives its bump from tags too — it had the same latent bug |
| `validate-catalog-source-sync.py` | Channel pointers must name a **tagged** release |
| `notes/` | Fragment directory + contributor guide |

## Verified

- Regressed catalog → still resolves forward (above)
- `next`: patch → 4.13.1, minor → 4.14.0, major → 5.0.0
- `apply` with a fragment → exactly 2 changed lines, formatting preserved
- No fragment → falls back to PR title; no fragment *and* no fallback → exits 1
- `betaVersion` pointed at untagged 4.11.11 → validator rejects it
- Every `${{ }}` reaches the shell via `env`, never inlined — a fork PR title is attacker-controlled and would otherwise be injectable
- All three scripts compile; both workflows parse; `bash -n` clean

## Note on merging

Merging this exercises the new path immediately — the post-merge push runs the new `release.yml`, which should publish **4.14.0** (this PR is labelled `release:minor`). That's the intended live test; if it misbehaves, `release.yml` is the only thing to revert.

Still outstanding, deliberately not in here: `@v4` tracks the dev tip rather than `stableVersion`, so clients receive everything the moment it merges. That changes delivery semantics for all 38 clients and deserves its own PR and an announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)