### PR TITLE
Reusable workflow pins its tooling at v4, not v1

### DIFF
--- a/.github/labview-ci/notes/reusable-workflow-v4-pins.md
+++ b/.github/labview-ci/notes/reusable-workflow-v4-pins.md
@@ -1,0 +1,6 @@
+The reusable workflow no longer reaches back into the v1 tooling line. It had
+kept pinning its config reader to `@v1`, and repos whose install manifest omits
+`source.ref` were falling back to `v1` for every capability — so a client on
+`@v4` could run v4 workflow logic over v1-era actions, most visibly the older
+VI Snapshots renderer without the interactive VI browser. Both now default to
+`v4`, matching the alias clients pin.

--- a/.github/workflows/labview-ci.reusable.yml
+++ b/.github/workflows/labview-ci.reusable.yml
@@ -1,5 +1,5 @@
 # Reusable workflow (lives at .github/workflows/ in the standalone labview-ci repo).
-# Consumers call this with `uses: your-org/labview-ci/.github/workflows/labview-ci.reusable.yml@v1`.
+# Consumers call this with `uses: your-org/labview-ci/.github/workflows/labview-ci.reusable.yml@v4`.
 #
 # This is where repo settings actually DRIVE behavior: a `config` job reads the
 # consumer's .github/labview-ci.yml via the load-config action, and each activity
@@ -44,21 +44,24 @@ jobs:
       # own .github/labview-ci.yml (source.ref). The capability jobs check out the
       # tooling at this ref and run it, so a repo only changes versions when it
       # edits that config file (via the token-free "Update now" button) — never
-      # automatically. Defaults to v1 when the config omits a ref.
+      # automatically. Defaults to v4 (the current stable alias) when the config
+      # omits a ref.
       tooling-ref:     ${{ steps.ref.outputs.ref }}
     steps:
       - uses: actions/checkout@v5
       - id: cfg
         # Full repo path (not ./actions/...): inside a reusable workflow a ./ path
         # resolves against the CALLER's checked-out workspace, which doesn't contain
-        # this repo's actions. Pin to the same major alias consumers use (@v1).
-        uses: elijah286/LabVIEW-CI-with-Containers/actions/load-config@v1
+        # this repo's actions. Pin to the same major alias consumers use (@v4) —
+        # an older alias here silently pairs current workflow logic with an
+        # earlier major's action, so this must move with every major bump.
+        uses: elijah286/LabVIEW-CI-with-Containers/actions/load-config@v4
       - id: ref
         shell: bash
         run: |
           REF=$(awk '/^[[:space:]]*ref:[[:space:]]/{print $2; exit}' .github/labview-ci.yml 2>/dev/null)
-          echo "ref=${REF:-v1}" >> "$GITHUB_OUTPUT"
-          echo "Capability version (source.ref) this repo opted into: ${REF:-v1}"
+          echo "ref=${REF:-v4}" >> "$GITHUB_OUTPUT"
+          echo "Capability version (source.ref) this repo opted into: ${REF:-v4}"
 
   # 1b) Dependency gate. If a worker rebuild is in progress for this SHA (an
   #     opt-in dependency update, or a worker-input change), the container


### PR DESCRIPTION
## What

`.github/workflows/labview-ci.reusable.yml` reached back into the v1 tooling line in two places. Both now say `v4`.

| Line | Was | Now |
|---|---|---|
| 55 | `uses: .../actions/load-config@v1` | `@v4` |
| 60–61 | `ref=${REF:-v1}` | `${REF:-v4}` |

Plus the stale comments on lines 2, 47 and 54.

## Is it a real defect?

Partly — and the more serious half is the `${REF:-v1}` fallback, not the pin that prompted the investigation.

**The `load-config@v1` pin (line 55) is interface-compatible today.** `v1` resolves to `v1.14.1` (`eb934a8`). Diffing `actions/load-config/action.yml` at `v1` vs `v4` shows one change: a `has-antidoc` output added. The reusable workflow consumes seven outputs (`labview-version`, `os-windows`, `os-linux`, `has-{masscompile,vi-analyzer,vidiff,snapshots}`) and all seven exist identically at `v1`; the parsing logic is otherwise byte-identical. So it was not silently breaking anything — but load-config is precisely the action whose output surface grows with each new capability, and `has-antidoc` is the proof. The next capability added would have been silently invisible to a `@v1` pin.

**The `${REF:-v1}` fallback (line 60) is the live problem.** That ref drives the runtime `_lvci` checkout for every capability job, so a consumer whose install manifest omits `source.ref` ran v1-era implementations of masscompile, vi-analyzer, vidiff and snapshots under v4 workflow logic. Interfaces match there too — `diff` of the `inputs:`/`outputs:` blocks at `v1` vs `v4` is empty for all five actions — but the implementations are not equal:

```
load-config:  +3/-1     (has-antidoc)
masscompile:  identical
vi-analyzer:  identical
vidiff:       identical
snapshots:    +1848/-37 across 5 files
```

Snapshots is the one that actually bites: `vi-render.js` (355 lines) does not exist at `v1` at all, and `vi-browser.html` is 1299 lines behind. Such a consumer got a v4 pipeline rendering v1 snapshot galleries.

The configurator writes an explicit pinned ref (the manifest in this repo carries `ref: v4.11.10`), so the fallback only fires for hand-written or legacy configs — which is why this went unnoticed.

## Why `@v4` and not `@v4.15.0`

Per #53, `@v<major>` now tracks the **stable** channel rather than the development tip — `v4` is at `770d7cf` (4.14.1) while main is at 4.15.0. `@v4` is what README.md:73 tells consumers to pin, so the workflow now matches them, which is what the original comment intended.

## Verification

- `git diff v1 v4 -- actions/<name>/action.yml` on the `inputs:`/`outputs:` blocks for all five actions
- Confirmed all seven outputs the config job reads exist in `load-config@v4`
- `yaml.safe_load` on the edited workflow
- No `v1` occurrences remain in the file

## Not changed

The `Pin by tag (@v1)` header comments in `actions/{vidiff,snapshots,masscompile,vi-analyzer,dashboard}/action.yml` and `.github/workflows/example-ci.yml:4` are stale the same way. They are documentation only, outside the file under review, and left for a separate pass.

Release note fragment added; label `release:patch`. `catalog.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)