### PR TITLE
Version-stamp vendored workflows so updates re-register them on forks

### DIFF
--- a/.github/labview-ci/install.py
+++ b/.github/labview-ci/install.py
@@ -53,6 +53,33 @@ NO_SUBSTITUTION_PREFIX = ".github/labview-ci/"
 DEFAULT_EXCLUDED_STATUSES = {"planned", "experimental"}
 GITHUB_WORKFLOW_PREFIX = ".github/workflows/"
 
+# Every vendored workflow file gets a first-line version stamp when installed or
+# updated. The stamp is not decoration: GitHub only registers a workflow file
+# (making it dispatchable via the API and listed under Actions) when a push
+# touches it while Actions is enabled, or when an event first runs it. Fork
+# installs typically push the whole pipeline while Actions is still disabled, so
+# every workflow_dispatch-only workflow stays permanently unregistered -- the
+# file exists on the default branch, yet dispatching it returns 404 forever
+# (the dashboard's Reconfigure / "Save monitored files" buttons hit exactly
+# this). An update can only heal that by touching the file, and git only
+# records files whose CONTENT changed -- so the stamp embeds the tooling
+# version, guaranteeing every "Update now" rewrites every workflow file and the
+# update push (re)registers any that were stuck.
+WORKFLOW_STAMP_RE = re.compile(r"^# LabVIEW CI tooling v[^\n]*\n")
+
+
+def stamp_workflow(text: str, version: str) -> str:
+    """Prepend (or refresh, when re-installing over an already-stamped copy) the
+    single-line tooling-version stamp comment on a workflow file."""
+    stamp = (f"# LabVIEW CI tooling v{version} - this version stamp changes on every tooling "
+             "update so the update push touches this file and GitHub (re)registers the workflow.\n")
+    return stamp + WORKFLOW_STAMP_RE.sub("", text, count=1)
+
+
+def should_stamp(rel_path: str) -> bool:
+    norm = rel_path.replace("\\", "/")
+    return norm.startswith(GITHUB_WORKFLOW_PREFIX) and Path(norm).suffix.lower() in (".yml", ".yaml")
+
 
 def log(msg: str = "") -> None:
     print(msg, flush=True)
@@ -218,7 +245,8 @@ def apply_substitutions(text: str, subs: list[tuple[str, str]]) -> str:
 
 def copy_one(src: Path, dst: Path, rel_path: str, subs: list[tuple[str, str]],
              force: bool, dry_run: bool, stats: dict,
-             preserve: set = frozenset(), update: bool = False) -> None:
+             preserve: set = frozenset(), update: bool = False,
+             stamp_version: str = "") -> None:
     norm = rel_path.replace("\\", "/")
     # On update, never clobber the consumer's own config files.
     if update and norm in preserve and dst.exists():
@@ -235,10 +263,16 @@ def copy_one(src: Path, dst: Path, rel_path: str, subs: list[tuple[str, str]],
         log(f"  would {'update ' if (update and existed) else 'install'}  {rel_path}")
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
-    if subs and should_substitute(rel_path):
+    wants_subs = bool(subs) and should_substitute(rel_path)
+    wants_stamp = bool(stamp_version) and should_stamp(rel_path)
+    if wants_subs or wants_stamp:
         try:
             text = src.read_text(encoding="utf-8")
-            dst.write_text(apply_substitutions(text, subs), encoding="utf-8")
+            if wants_subs:
+                text = apply_substitutions(text, subs)
+            if wants_stamp:
+                text = stamp_workflow(text, stamp_version)
+            dst.write_text(text, encoding="utf-8")
         except UnicodeDecodeError:
             shutil.copy2(src, dst)
     else:
@@ -253,7 +287,8 @@ def copy_one(src: Path, dst: Path, rel_path: str, subs: list[tuple[str, str]],
 
 def copy_entry(entry: str, source_root: Path, target_root: Path,
                subs: list[tuple[str, str]], force: bool, dry_run: bool, stats: dict,
-               preserve: set = frozenset(), update: bool = False) -> None:
+               preserve: set = frozenset(), update: bool = False,
+               stamp_version: str = "") -> None:
     is_dir = entry.endswith("/")
     src = source_root / entry
     if is_dir:
@@ -265,7 +300,7 @@ def copy_entry(entry: str, source_root: Path, target_root: Path,
             if child.is_file():
                 rel = child.relative_to(source_root).as_posix()
                 source_files.add(rel)
-                copy_one(child, target_root / rel, rel, subs, force, dry_run, stats, preserve, update)
+                copy_one(child, target_root / rel, rel, subs, force, dry_run, stats, preserve, update, stamp_version)
         # On update, mirror the source: prune tooling files that the source has
         # REMOVED so a vendored directory matches the source exactly. Without this,
         # a file the tooling deletes (e.g. an obsolete Go source) lingers on the
@@ -303,7 +338,7 @@ def copy_entry(entry: str, source_root: Path, target_root: Path,
         if not src.is_file():
             warn(f"missing source file {entry} - skipping.")
             return
-        copy_one(src, target_root / entry, entry, subs, force, dry_run, stats, preserve, update)
+        copy_one(src, target_root / entry, entry, subs, force, dry_run, stats, preserve, update, stamp_version)
 
 
 def write_manifest(target_root: Path, catalog: dict, activities: list[str], os_list: list[str],
@@ -960,9 +995,10 @@ def main() -> int:
     if args.provider == "gitlab":
         file_list = [f for f in file_list if not f.replace("\\", "/").startswith(GITHUB_WORKFLOW_PREFIX)]
     stats = {"installed": 0, "updated": 0, "skipped": 0, "planned": 0, "preserved": 0, "pruned": 0}
+    stamp_version = str(catalog.get("version", "0.0.0"))
     for entry in file_list:
         copy_entry(entry, source_root, target_root, subs, force, args.dry_run, stats,
-                   preserve, update)
+                   preserve, update, stamp_version)
 
     # The dashboard generator (actions/dashboard) is a local path that only exists
     # in the tooling repo and can't be rebranded into a consumer, so the vendored

--- a/.github/labview-ci/notes/fork-workflow-registration-stamp.md
+++ b/.github/labview-ci/notes/fork-workflow-registration-stamp.md
@@ -1,0 +1,8 @@
+Every vendored workflow file now carries a tooling-version stamp, so each update
+rewrites every workflow file and the update push makes GitHub (re)register them.
+This heals repositories -- typically fork installs whose pipeline was pushed while
+Actions was still disabled -- where dispatch-only workflows like Reconfigure
+existed on the default branch but were never registered, so the dashboard's "Save
+monitored files" and container-update buttons failed with HTTP 404 no matter what
+token was supplied. The Dependencies and Configure pages now also tell this case
+apart from a real token problem and say exactly how to fix it.

--- a/actions/dashboard/configure.html
+++ b/actions/dashboard/configure.html
@@ -1270,6 +1270,21 @@
       const inp = $("tokInput"); if (inp) inp.focus();
     }
     function hideTokenPanel() { const p = $("tokPanel"); if (p) p.hidden = true; }
+    // A dispatch 404 has three distinct causes: the token cannot see the repo, the
+    // workflow file is not installed, or -- the sneaky one -- the file EXISTS but
+    // GitHub never registered it as a workflow. Fork installs push the pipeline
+    // while Actions is still disabled, and GitHub only registers a workflow file
+    // when a push touches it while Actions is enabled (or an event first runs it),
+    // so a dispatch-only workflow can 404 forever with a perfectly good token.
+    // Probe the file anonymously (works on public repos; on private repos this
+    // yields "" and the token guidance stands) so the fix offered is the right one.
+    async function explainDispatch404(repo, file) {
+      try {
+        const r = await fetch("https://api.github.com/repos/" + repo + "/contents/.github/workflows/" + file, { headers: { "Accept": "application/vnd.github+json" }, cache: "no-cache" });
+        if (r.ok) return "<strong>Not a token problem</strong> — <code class=\"inl\">" + escapeHtml(file) + "</code> exists in this repository, but GitHub has not registered it as a runnable workflow, so dispatching it returns 404. This happens when workflow files were pushed while GitHub Actions was disabled (typical for fork installs). Fix: run <strong>What's New ▸ Update now</strong> — tooling updates rewrite every workflow file (each carries a version stamp), and that push makes GitHub register them — or push any commit that edits <code class=\"inl\">.github/workflows/" + escapeHtml(file) + "</code>, then retry.";
+      } catch (_) {}
+      return "";
+    }
     async function dispatchReconfigure() {
       const repo = $("repo").value.trim();
       if (!repo.includes("/")) { setApplyStatus("Choose a repository before applying.", "err"); return; }
@@ -1291,7 +1306,13 @@
         }
         if (r.status === 401) { try { localStorage.removeItem(TOK_KEY); } catch (_) {} showTokenPanel("That token was rejected. Paste a valid fine-grained token with <strong>Actions: Read and write</strong> for this repository."); setApplyStatus("Token rejected (401).", "err"); return; }
         if (r.status === 403) { showTokenPanel("The saved token cannot dispatch workflows here. Grant <strong>Actions: Read and write</strong> for <code class=\"inl\">" + escapeHtml(repo) + "</code>."); setApplyStatus("Dispatch forbidden (403).", "err"); return; }
-        if (r.status === 404) { showTokenPanel("The saved token cannot see <code class=\"inl\">" + escapeHtml(repo) + "</code>, or this repo does not have <code class=\"inl\">reconfigure.yml</code> installed."); setApplyStatus("Workflow not found or repo not accessible (404).", "err"); return; }
+        if (r.status === 404) {
+          const unregistered = await explainDispatch404(repo, "reconfigure.yml");
+          if (unregistered) { hideTokenPanel(); setApplyStatus(unregistered, "err"); return; }
+          showTokenPanel("The saved token cannot see <code class=\"inl\">" + escapeHtml(repo) + "</code>, or this repo does not have <code class=\"inl\">reconfigure.yml</code> installed.");
+          setApplyStatus("Workflow not found or repo not accessible (404).", "err");
+          return;
+        }
         setApplyStatus("Dispatch failed (HTTP " + r.status + ").", "err");
       } catch (e) {
         if (btn) { btn.disabled = false; btn.textContent = "Save and apply"; }

--- a/actions/dashboard/dashboard.py
+++ b/actions/dashboard/dashboard.py
@@ -2674,9 +2674,13 @@ run_dialog = (r"""
     // history doesn't trip GitHub's secondary rate limits. Resolves with an
     // {ok, err, total} tally; the caller owns its own status line + buttons.
     // Turn collected dispatch failures into an accurate message. A 404 means the
-    // targeted workflow file is not installed on this repo (its LabVIEW CI tooling
-    // is out of date) -- NOT a token problem -- so callers do not re-prompt for a
-    // token in that case. .tok = whether the failure is token/permission related.
+    // targeted workflow is not RUNNABLE on this repo -- the file is not installed
+    // (tooling out of date), or it exists but GitHub never registered it as a
+    // workflow (fork installs that pushed the files while Actions was disabled) --
+    // NOT a token problem, so callers do not re-prompt for a token in that case.
+    // Both causes share one remedy: a tooling update rewrites every workflow file
+    // (version stamp), so the update push registers them. .tok = whether the
+    // failure is token/permission related.
     function dispatchFailMsg(fails){
       fails = fails || [];
       var has = function(code){ return fails.some(function(f){ return f.status===code; }); };
@@ -2684,7 +2688,7 @@ run_dialog = (r"""
       if(has(404)){
         var wfs=[]; fails.forEach(function(f){ if(f.status===404 && f.wf && wfs.indexOf(f.wf)<0) wfs.push(f.wf); });
         var list=wfs.map(function(w){ return '<code>'+esc(w)+'</code>'; }).join(', ');
-        return { html:'<strong>Not a token problem</strong> \u2014 your saved token worked, but '+(wfs.length>1?'these workflows are':'this workflow is')+' not installed on <code>'+esc(REPO)+'</code> (HTTP 404): '+list+'. This repository\u2019s LabVIEW CI tooling is out of date \u2014 update it from <strong>What\u2019s new \u2192 Update</strong> to add the missing workflow'+(wfs.length>1?'s':'')+', then queue again.', tok:false };
+        return { html:'<strong>Not a token problem</strong> \u2014 your saved token worked, but '+(wfs.length>1?'these workflows are':'this workflow is')+' not runnable on <code>'+esc(REPO)+'</code> (HTTP 404): '+list+'. Either the file is not installed (this repository\u2019s LabVIEW CI tooling is out of date), or it exists but GitHub never registered it as a workflow \u2014 typical for fork installs that pushed the pipeline while Actions was disabled. Both have the same fix: update from <strong>What\u2019s new \u2192 Update</strong> \u2014 the update rewrites every workflow file so GitHub registers '+(wfs.length>1?'them':'it')+' \u2014 then queue again.', tok:false };
       }
       if(has(403)) return { html:'The saved token is missing the <strong>Actions: Read and write</strong> permission on <code>'+esc(REPO)+'</code> (HTTP 403). On the token page set <strong>Permissions \u2192 Repository permissions \u2192 Actions \u2192 Read and write</strong>, then <strong>Update</strong>. <a href="'+tokenSetupUrl()+'" target="_blank" rel="noopener" style="color:var(--link)">Update token \u2197</a>', tok:true };
       if(has(422)) return { html:'GitHub rejected the dispatch (HTTP 422) \u2014 usually a bad branch ref (<code>'+esc(BRANCH)+'</code>) or inputs.', tok:false };

--- a/actions/dashboard/dependencies.html
+++ b/actions/dashboard/dependencies.html
@@ -505,6 +505,22 @@
       else setMonitorStatus(counts.monitored + " of " + counts.total + " dependency files monitored.", "ok");
     }
     function token(){ try { return localStorage.getItem(TOK_KEY) || ""; } catch (_) { return ""; } }
+    // A dispatch 404 has three distinct causes: the token cannot see the repo, the
+    // workflow file is not installed, or -- the sneaky one -- the file EXISTS but
+    // GitHub never registered it as a workflow. Fork installs push the pipeline
+    // while Actions is still disabled, and GitHub only registers a workflow file
+    // when a push touches it while Actions is enabled (or an event first runs it),
+    // so a dispatch-only workflow can 404 forever with a perfectly good token.
+    // Probe the file anonymously (works on public repos; on private repos this
+    // yields "" and the token guidance stands) so the fix offered is the right one.
+    async function explainDispatch404(file){
+      if (!repo.includes("/")) return "";
+      try {
+        const r = await fetch("https://api.github.com/repos/" + repo + "/contents/.github/workflows/" + file, { headers:{ "Accept":"application/vnd.github+json" }, cache:"no-cache" });
+        if (r.ok) return "<strong>Not a token problem</strong> — <code>" + esc(file) + "</code> exists in this repository, but GitHub has not registered it as a runnable workflow, so dispatching it returns 404. This happens when workflow files were pushed while GitHub Actions was disabled (typical for fork installs). Fix: run <strong>What's New ▸ Update now</strong> — tooling updates rewrite every workflow file (each carries a version stamp), and that push makes GitHub register them — or push any commit that edits <code>.github/workflows/" + esc(file) + "</code>, then retry.";
+      } catch (_) {}
+      return "";
+    }
     function workflowRef(){ return (generatedInventory && (generatedInventory.ref || generatedInventory.defaultBranch)) || "main"; }
     function workflowUrl(){ return repo.includes("/") ? "https://github.com/" + repo + "/actions/workflows/reconfigure.yml" : "https://github.com/actions/workflows/reconfigure.yml"; }
     function tokenUrl(){
@@ -548,7 +564,13 @@
         if (btn) btn.disabled = false;
         if (r.status === 401) { try { localStorage.removeItem(TOK_KEY); } catch (_) {} showTokenPanel("That token was rejected. Paste a valid fine-grained token with <strong>Actions: Read and write</strong> for this repository."); setMonitorStatus("Token rejected (401).", "err"); return; }
         if (r.status === 403) { showTokenPanel("The saved token cannot dispatch workflows here. Grant <strong>Actions: Read and write</strong> for <code>" + esc(repo) + "</code>."); setMonitorStatus("Dispatch forbidden (403).", "err"); return; }
-        if (r.status === 404) { showTokenPanel("The saved token cannot see <code>" + esc(repo) + "</code>, or this repo does not have <code>reconfigure.yml</code> installed."); setMonitorStatus("Workflow not found or repo not accessible (404).", "err"); return; }
+        if (r.status === 404) {
+          const unregistered = await explainDispatch404("reconfigure.yml");
+          if (unregistered) { hideTokenPanel(); setMonitorStatus(unregistered, "err"); return; }
+          showTokenPanel("The saved token cannot see <code>" + esc(repo) + "</code>, or this repo does not have <code>reconfigure.yml</code> installed.");
+          setMonitorStatus("Workflow not found or repo not accessible (404).", "err");
+          return;
+        }
         setMonitorStatus("Dispatch failed (HTTP " + r.status + ").", "err");
       } catch (e) {
         if (btn) { btn.disabled = false; btn.textContent = "Save monitored files"; }
@@ -764,7 +786,14 @@
           if (btn) { btn.disabled = false; btn.textContent = "Run the container update"; }
           if (r.status === 401) { try { localStorage.removeItem(TOK_KEY); } catch (_) {} pendingTokenAction = dispatchContainerUpdate; showTokenPanel("That token was rejected. Paste a valid fine-grained token with <strong>Actions: Read and write</strong> for this repository."); setUpdateStatus("Token rejected (401).", "err"); return; }
           if (r.status === 403) { pendingTokenAction = dispatchContainerUpdate; showTokenPanel("The saved token cannot dispatch workflows here. Grant <strong>Actions: Read and write</strong> for <code>" + esc(repo) + "</code>."); setUpdateStatus("Dispatch forbidden (403).", "err"); return; }
-          if (r.status === 404) { pendingTokenAction = dispatchContainerUpdate; showTokenPanel("The saved token cannot see <code>" + esc(repo) + "</code>, or this repo does not have <code>" + esc(t.file) + "</code> installed."); setUpdateStatus("Workflow <code>" + esc(t.file) + "</code> not found or repo not accessible (404).", "err"); return; }
+          if (r.status === 404) {
+            const unregistered = await explainDispatch404(t.file);
+            if (unregistered) { hideTokenPanel(); setUpdateStatus(unregistered, "err"); return; }
+            pendingTokenAction = dispatchContainerUpdate;
+            showTokenPanel("The saved token cannot see <code>" + esc(repo) + "</code>, or this repo does not have <code>" + esc(t.file) + "</code> installed.");
+            setUpdateStatus("Workflow <code>" + esc(t.file) + "</code> not found or repo not accessible (404).", "err");
+            return;
+          }
           setUpdateStatus("Dispatch of <code>" + esc(t.file) + "</code> failed (HTTP " + r.status + ").", "err");
           return;
         }


### PR DESCRIPTION
## The bug

On a fork install (observed on `elijah286/LabVIEW-CLI-testing-DCOONS`), the Dependencies page's **Save monitored files** fails with *"Workflow not found or repo not accessible (404)"* and then blames the saved token — but no token can fix it. The repo has 24 workflow files on `main`, yet GitHub's Actions API lists only 9 of them: `reconfigure.yml` and 15 other `workflow_dispatch`-only workflows were pushed while Actions was still disabled on the fork, so GitHub never registered them, and dispatch-by-filename 404s forever.

Tooling updates never healed this because git only commits files whose content changed: the 4.16.4 → 4.17.0 updates touched (and thereby registered) `dashboard-pages.yml`, the copy/build workflows, etc., while every workflow YAML that was byte-identical across versions stayed unregistered. Same class of failure as #58, which fixed it for the copy-seed workflows only.

## The fix

- **install.py** writes a single-line tooling-version stamp at the top of every vendored `.github/workflows/*.yml`. Every *Update now* therefore rewrites every workflow file, and the update push makes GitHub (re)register any that were stuck. Idempotent (the stamp is replaced, never duplicated); re-running at the same version produces byte-identical files, so "Already up to date" still short-circuits.
- **Dependencies + Configure pages**: on a dispatch 404 they now probe the workflow file anonymously (public repos) and, when it exists, explain the real cause and the fix (run *Update now*, or push any commit touching the file) instead of showing the token panel. Private repos keep the existing token guidance.
- **Queue dialog** 404 hint names both causes (file not installed vs. unregistered) — the remedy is the same update either way.

## Verification

- Fresh install into a temp target: all vendored workflows carry the stamp as line 1 with original content intact below; `--update` re-run keeps exactly one stamp line.
- `py_compile` on install.py + dashboard.py; `node --check` on every inline script in both HTML pages.
- Anonymous contents probe verified against the affected fork (200 for an existing-but-unregistered workflow file).

Default patch bump — release-note fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)