### PR TITLE
Install watcher: don't misread a cancelled copy-twin as a failed seed

### DIFF
--- a/.github/labview-ci/notes/install-watcher-twin-cancel.md
+++ b/.github/labview-ci/notes/install-watcher-twin-cancel.md
@@ -1,0 +1,7 @@
+The configurator's install progress no longer reports "one worker image did not
+finish successfully" when the image actually seeded fine. A fork install starts
+each copy workflow twice -- the page dispatches it and the install merge's own
+push trigger fires it -- and their shared concurrency lane cancels one of the
+twins while it is still queued. The watcher used to judge only the newest run, so
+when the cancelled twin was the newer one it showed a false warning; it now
+prefers a successful run of that workflow from the same install before judging.

--- a/actions/dashboard/integrate.html
+++ b/actions/dashboard/integrate.html
@@ -2112,12 +2112,24 @@
     }
 
     async function latestWorkflowRun(repo, workflowFile, branch, sinceMs) {
+      // The install merge can legitimately create TWIN runs of a copy workflow:
+      // this page dispatches it AND the file's own push trigger fires from the
+      // merge (the fork self-heal, #58). Their shared concurrency lane runs one
+      // twin and CANCELS the other while it is still pending -- and which twin
+      // dies is a race. Judging the NEWEST run alone therefore misreads a
+      // successful seed as "finished with cancelled" (observed on a fork
+      // install: the Linux dispatch run succeeded while its newer push twin was
+      // cancelled, and the watcher happened to track the twin). Prefer, among
+      // the runs since the cutoff: any SUCCESS, else any still-active run (keep
+      // waiting on it), else the newest completed one.
       try {
         const r = await gh(`/repos/${repo}/actions/workflows/${workflowFile}/runs?branch=${encodeURIComponent(branch)}&per_page=10`);
         if (!r.ok) return null;
         const cutoff = (sinceMs || 0) - 60000;
-        const runs = ((await r.json()).workflow_runs || []).filter(x => x && x.created_at);
-        return runs.find(x => Date.parse(x.created_at) >= cutoff) || null;
+        const runs = ((await r.json()).workflow_runs || []).filter(x => x && x.created_at && Date.parse(x.created_at) >= cutoff);
+        return runs.find(x => x.status === "completed" && x.conclusion === "success")
+            || runs.find(x => x.status !== "completed")
+            || runs[0] || null;
       } catch (_) { return null; }
     }
 


### PR DESCRIPTION
## The false alarm

Installing into a fork (`elijah286/LabVIEW-CLI-testing-DCOONS`, 2026-08-23 22:07Z) ended with the configurator showing *"At least one worker image did not finish successfully from this browser"* — but **both worker images seeded fine** (fresh `workers/{windows,linux}/latest.json` manifests published from the install sha).

Since #58, an install merge starts each copy workflow **twice**: the configurator dispatches it, and the workflow file's own push trigger fires from the merge. The twins share the copy/build concurrency lane, which runs one and **cancels the other while it is still pending** (zero jobs). Which twin dies is a race — on this install Windows kept the push twin, Linux kept the dispatch twin.

`latestWorkflowRun` judged only the *newest* run since the install, so when the cancelled twin was the newer one (Linux here) the watcher tracked it, saw `cancelled`, and reported the warning.

## The fix

Among the runs created since the install cutoff, prefer: any **success**, else any **still-active** run (keep waiting on it), else the newest completed one. A run cancelled by its twin always has that sibling already in the run list — the sibling's queueing is what cancelled it — so the selection cannot miss it, while a genuinely failed or hand-cancelled lone run still reports honestly.

Verified with `node --check` on every inline script; release-note fragment included (default patch bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)